### PR TITLE
feat: add configuration and workflow endpoints

### DIFF
--- a/internal/handlers/audit_log.go
+++ b/internal/handlers/audit_log.go
@@ -1,0 +1,36 @@
+package handlers
+
+import (
+	"net/http"
+
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AuditLogHandler handles retrieval of audit logs
+type AuditLogHandler struct {
+	service *services.AuditLogService
+}
+
+func NewAuditLogHandler() *AuditLogHandler {
+	return &AuditLogHandler{service: services.NewAuditLogService()}
+}
+
+// GET /audit-logs
+func (h *AuditLogHandler) GetAuditLogs(c *gin.Context) {
+	filters := map[string]string{
+		"user_id":   c.Query("user_id"),
+		"action":    c.Query("action"),
+		"from_date": c.Query("from_date"),
+		"to_date":   c.Query("to_date"),
+	}
+
+	logs, err := h.service.GetAuditLogs(filters)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get audit logs", err)
+		return
+	}
+	utils.SuccessResponse(c, "Audit logs retrieved successfully", logs)
+}

--- a/internal/handlers/print.go
+++ b/internal/handlers/print.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"net/http"
+
+	"erp-backend/internal/models"
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// PrintHandler triggers print operations
+type PrintHandler struct {
+	service *services.PrintService
+}
+
+func NewPrintHandler() *PrintHandler {
+	return &PrintHandler{service: services.NewPrintService()}
+}
+
+// POST /print/receipt
+func (h *PrintHandler) PrintReceipt(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	var req models.PrintReceiptRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+
+	if err := h.service.PrintReceipt(req.Type, req.ReferenceID, companyID); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to print receipt", err)
+		return
+	}
+	utils.SuccessResponse(c, "Print command sent", nil)
+}

--- a/internal/handlers/settings.go
+++ b/internal/handlers/settings.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"net/http"
+
+	"erp-backend/internal/models"
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// SettingsHandler handles HTTP requests for system settings
+type SettingsHandler struct {
+	service *services.SettingsService
+}
+
+func NewSettingsHandler() *SettingsHandler {
+	return &SettingsHandler{service: services.NewSettingsService()}
+}
+
+// GET /settings
+func (h *SettingsHandler) GetSettings(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	settings, err := h.service.GetSettings(companyID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get settings", err)
+		return
+	}
+	utils.SuccessResponse(c, "Settings retrieved successfully", settings)
+}
+
+// PUT /settings
+func (h *SettingsHandler) UpdateSettings(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	var req models.UpdateSettingsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+
+	if err := h.service.UpdateSettings(companyID, req.Settings); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update settings", err)
+		return
+	}
+
+	utils.SuccessResponse(c, "Settings updated successfully", nil)
+}

--- a/internal/handlers/translation.go
+++ b/internal/handlers/translation.go
@@ -1,0 +1,56 @@
+package handlers
+
+import (
+	"net/http"
+
+	"erp-backend/internal/models"
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TranslationHandler manages translation endpoints
+type TranslationHandler struct {
+	service *services.TranslationService
+}
+
+func NewTranslationHandler() *TranslationHandler {
+	return &TranslationHandler{service: services.NewTranslationService()}
+}
+
+// GET /translations
+func (h *TranslationHandler) GetTranslations(c *gin.Context) {
+	lang := c.Query("lang")
+	if lang == "" {
+		lang = "en"
+	}
+
+	translations, err := h.service.GetTranslations(lang)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get translations", err)
+		return
+	}
+	utils.SuccessResponse(c, "Translations retrieved successfully", translations)
+}
+
+// PUT /translations
+func (h *TranslationHandler) UpdateTranslations(c *gin.Context) {
+	var req models.UpdateTranslationsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+
+	if err := h.service.UpdateTranslations(req.Lang, req.Strings); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update translations", err)
+		return
+	}
+
+	utils.SuccessResponse(c, "Translations updated successfully", nil)
+}

--- a/internal/handlers/workflow.go
+++ b/internal/handlers/workflow.go
@@ -1,0 +1,94 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"erp-backend/internal/models"
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// WorkflowHandler manages workflow approval requests
+type WorkflowHandler struct {
+	service *services.WorkflowService
+}
+
+func NewWorkflowHandler() *WorkflowHandler {
+	return &WorkflowHandler{service: services.NewWorkflowService()}
+}
+
+// GET /workflow-requests
+func (h *WorkflowHandler) GetWorkflowRequests(c *gin.Context) {
+	requests, err := h.service.GetPendingRequests()
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get workflow requests", err)
+		return
+	}
+	utils.SuccessResponse(c, "Workflow requests retrieved successfully", requests)
+}
+
+// POST /workflow-requests
+func (h *WorkflowHandler) CreateWorkflowRequest(c *gin.Context) {
+	var req models.CreateWorkflowRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+
+	if err := utils.ValidateStruct(&req); err != nil {
+		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
+		return
+	}
+
+	request, err := h.service.CreateRequest(&req)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to create workflow request", err)
+		return
+	}
+	utils.CreatedResponse(c, "Workflow request created successfully", request)
+}
+
+// PUT /workflow-requests/:id/approve
+func (h *WorkflowHandler) ApproveWorkflowRequest(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request id", err)
+		return
+	}
+
+	var req models.DecisionRequest
+	if err := c.ShouldBindJSON(&req); err != nil && err.Error() != "EOF" {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+
+	if err := h.service.ApproveRequest(id, req.Remarks); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to approve workflow request", err)
+		return
+	}
+	utils.SuccessResponse(c, "Workflow request approved", nil)
+}
+
+// PUT /workflow-requests/:id/reject
+func (h *WorkflowHandler) RejectWorkflowRequest(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request id", err)
+		return
+	}
+
+	var req models.DecisionRequest
+	if err := c.ShouldBindJSON(&req); err != nil && err.Error() != "EOF" {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+
+	if err := h.service.RejectRequest(id, req.Remarks); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to reject workflow request", err)
+		return
+	}
+	utils.SuccessResponse(c, "Workflow request rejected", nil)
+}

--- a/internal/models/audit_log.go
+++ b/internal/models/audit_log.go
@@ -1,0 +1,19 @@
+package models
+
+import "time"
+
+// AuditLog represents an entry in the audit_log table
+// It tracks changes and actions performed in the system.
+type AuditLog struct {
+	LogID        int       `json:"log_id" db:"log_id"`
+	UserID       *int      `json:"user_id,omitempty" db:"user_id"`
+	Action       string    `json:"action" db:"action"`
+	TableName    string    `json:"table_name" db:"table_name"`
+	RecordID     *int      `json:"record_id,omitempty" db:"record_id"`
+	OldValue     *JSONB    `json:"old_value,omitempty" db:"old_value"`
+	NewValue     *JSONB    `json:"new_value,omitempty" db:"new_value"`
+	FieldChanges *JSONB    `json:"field_changes,omitempty" db:"field_changes"`
+	IPAddress    *string   `json:"ip_address,omitempty" db:"ip_address"`
+	UserAgent    *string   `json:"user_agent,omitempty" db:"user_agent"`
+	Timestamp    time.Time `json:"timestamp" db:"timestamp"`
+}

--- a/internal/models/print.go
+++ b/internal/models/print.go
@@ -1,0 +1,8 @@
+package models
+
+// PrintReceiptRequest defines the payload to trigger a receipt print
+// Type refers to the entity type e.g. sale, purchase etc.
+type PrintReceiptRequest struct {
+	Type        string `json:"type" validate:"required"`
+	ReferenceID int    `json:"reference_id" validate:"required"`
+}

--- a/internal/models/settings.go
+++ b/internal/models/settings.go
@@ -1,0 +1,24 @@
+package models
+
+import "time"
+
+// Setting represents a configurable key-value pair in the system
+// It maps to the settings table.
+type Setting struct {
+	SettingID   int       `json:"setting_id" db:"setting_id"`
+	CompanyID   int       `json:"company_id" db:"company_id"`
+	LocationID  *int      `json:"location_id,omitempty" db:"location_id"`
+	Key         string    `json:"key" db:"key"`
+	Value       string    `json:"value" db:"value"`
+	Description *string   `json:"description,omitempty" db:"description"`
+	DataType    string    `json:"data_type" db:"data_type"`
+	CreatedAt   time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at" db:"updated_at"`
+}
+
+// UpdateSettingsRequest is used to update multiple settings at once
+// The map key represents the setting key and value represents the setting value
+// Example: {"currency":"INR"}
+type UpdateSettingsRequest struct {
+	Settings map[string]string `json:"settings" validate:"required"`
+}

--- a/internal/models/translation.go
+++ b/internal/models/translation.go
@@ -1,0 +1,21 @@
+package models
+
+import "time"
+
+// Translation represents a localized string
+// It corresponds to the translations table.
+type Translation struct {
+	TranslationID int       `json:"translation_id" db:"translation_id"`
+	Key           string    `json:"key" db:"key"`
+	LanguageCode  string    `json:"language_code" db:"language_code"`
+	Value         string    `json:"value" db:"value"`
+	Context       *string   `json:"context,omitempty" db:"context"`
+	CreatedAt     time.Time `json:"created_at" db:"created_at"`
+}
+
+// UpdateTranslationsRequest is used to update translation strings for a language
+// Lang represents the language code and Strings is a map of key-value pairs.
+type UpdateTranslationsRequest struct {
+	Lang    string            `json:"lang" validate:"required"`
+	Strings map[string]string `json:"strings" validate:"required"`
+}

--- a/internal/models/workflow.go
+++ b/internal/models/workflow.go
@@ -1,0 +1,25 @@
+package models
+
+import "time"
+
+// WorkflowRequest represents a workflow approval request
+// It corresponds to the workflow_approvals table.
+type WorkflowRequest struct {
+	ApprovalID     int        `json:"approval_id" db:"approval_id"`
+	StateID        int        `json:"state_id" db:"state_id"`
+	ApproverRoleID int        `json:"approver_role_id" db:"approver_role_id"`
+	Status         string     `json:"status" db:"status"`
+	Remarks        *string    `json:"remarks,omitempty" db:"remarks"`
+	ApprovedAt     *time.Time `json:"approved_at,omitempty" db:"approved_at"`
+}
+
+// CreateWorkflowRequest is used to submit a new workflow approval request
+type CreateWorkflowRequest struct {
+	StateID        int `json:"state_id" validate:"required"`
+	ApproverRoleID int `json:"approver_role_id" validate:"required"`
+}
+
+// DecisionRequest contains optional remarks when approving or rejecting
+type DecisionRequest struct {
+	Remarks *string `json:"remarks,omitempty"`
+}

--- a/internal/services/audit_log_service.go
+++ b/internal/services/audit_log_service.go
@@ -1,0 +1,68 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"erp-backend/internal/database"
+	"erp-backend/internal/models"
+)
+
+// AuditLogService provides methods to query audit logs
+type AuditLogService struct {
+	db *sql.DB
+}
+
+func NewAuditLogService() *AuditLogService {
+	return &AuditLogService{db: database.GetDB()}
+}
+
+// GetAuditLogs retrieves logs based on provided filters
+func (s *AuditLogService) GetAuditLogs(filters map[string]string) ([]models.AuditLog, error) {
+	query := `SELECT log_id, user_id, action, table_name, record_id, old_value, new_value, field_changes, ip_address, user_agent, timestamp FROM audit_log`
+	args := []interface{}{}
+	conditions := []string{}
+	argCount := 1
+
+	if v, ok := filters["user_id"]; ok && v != "" {
+		conditions = append(conditions, fmt.Sprintf("user_id = $%d", argCount))
+		args = append(args, v)
+		argCount++
+	}
+	if v, ok := filters["action"]; ok && v != "" {
+		conditions = append(conditions, fmt.Sprintf("action = $%d", argCount))
+		args = append(args, v)
+		argCount++
+	}
+	if v, ok := filters["from_date"]; ok && v != "" {
+		conditions = append(conditions, fmt.Sprintf("timestamp >= $%d", argCount))
+		args = append(args, v)
+		argCount++
+	}
+	if v, ok := filters["to_date"]; ok && v != "" {
+		conditions = append(conditions, fmt.Sprintf("timestamp <= $%d", argCount))
+		args = append(args, v)
+		argCount++
+	}
+	if len(conditions) > 0 {
+		query += " WHERE " + strings.Join(conditions, " AND ")
+	}
+	query += " ORDER BY timestamp DESC"
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get audit logs: %w", err)
+	}
+	defer rows.Close()
+
+	var logs []models.AuditLog
+	for rows.Next() {
+		var log models.AuditLog
+		if err := rows.Scan(&log.LogID, &log.UserID, &log.Action, &log.TableName, &log.RecordID, &log.OldValue, &log.NewValue, &log.FieldChanges, &log.IPAddress, &log.UserAgent, &log.Timestamp); err != nil {
+			return nil, fmt.Errorf("failed to scan audit log: %w", err)
+		}
+		logs = append(logs, log)
+	}
+	return logs, nil
+}

--- a/internal/services/print_service.go
+++ b/internal/services/print_service.go
@@ -1,0 +1,26 @@
+package services
+
+import (
+	"fmt"
+	"log"
+)
+
+// PrintService provides printing capabilities
+// Currently it only logs the print request
+
+type PrintService struct{}
+
+func NewPrintService() *PrintService {
+	return &PrintService{}
+}
+
+// PrintReceipt handles printing a receipt for a given reference
+// The actual printing mechanism is outside the scope; we just log for now
+func (s *PrintService) PrintReceipt(printType string, referenceID int, companyID int) error {
+	log.Printf("Print requested: type=%s reference=%d company=%d", printType, referenceID, companyID)
+	// TODO: integrate with printer settings and templates
+	if referenceID == 0 {
+		return fmt.Errorf("invalid reference id")
+	}
+	return nil
+}

--- a/internal/services/settings_service.go
+++ b/internal/services/settings_service.go
@@ -1,0 +1,69 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+
+	"erp-backend/internal/database"
+)
+
+// SettingsService provides methods to manage system settings
+// It works with the settings table
+// Settings are stored as key-value pairs per company
+
+type SettingsService struct {
+	db *sql.DB
+}
+
+// NewSettingsService creates a new SettingsService
+func NewSettingsService() *SettingsService {
+	return &SettingsService{db: database.GetDB()}
+}
+
+// GetSettings retrieves all settings for a company
+func (s *SettingsService) GetSettings(companyID int) (map[string]string, error) {
+	query := `SELECT key, value FROM settings WHERE company_id = $1`
+	rows, err := s.db.Query(query, companyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get settings: %w", err)
+	}
+	defer rows.Close()
+
+	settings := make(map[string]string)
+	for rows.Next() {
+		var key, value string
+		if err := rows.Scan(&key, &value); err != nil {
+			return nil, fmt.Errorf("failed to scan setting: %w", err)
+		}
+		settings[key] = value
+	}
+
+	return settings, nil
+}
+
+// UpdateSettings updates or inserts multiple settings for a company
+func (s *SettingsService) UpdateSettings(companyID int, settings map[string]string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.Prepare(`INSERT INTO settings (company_id, key, value) VALUES ($1, $2, $3)
+            ON CONFLICT (company_id, key) DO UPDATE SET value = EXCLUDED.value, updated_at = CURRENT_TIMESTAMP`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare statement: %w", err)
+	}
+	defer stmt.Close()
+
+	for k, v := range settings {
+		if _, err := stmt.Exec(companyID, k, v); err != nil {
+			return fmt.Errorf("failed to upsert setting %s: %w", k, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit settings: %w", err)
+	}
+	return nil
+}

--- a/internal/services/translation_service.go
+++ b/internal/services/translation_service.go
@@ -1,0 +1,64 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+
+	"erp-backend/internal/database"
+)
+
+// TranslationService handles translation retrieval and updates
+type TranslationService struct {
+	db *sql.DB
+}
+
+func NewTranslationService() *TranslationService {
+	return &TranslationService{db: database.GetDB()}
+}
+
+// GetTranslations returns a map of translation key/value pairs for a language
+func (s *TranslationService) GetTranslations(lang string) (map[string]string, error) {
+	rows, err := s.db.Query(`SELECT key, value FROM translations WHERE language_code = $1`, lang)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get translations: %w", err)
+	}
+	defer rows.Close()
+
+	translations := make(map[string]string)
+	for rows.Next() {
+		var key, value string
+		if err := rows.Scan(&key, &value); err != nil {
+			return nil, fmt.Errorf("failed to scan translation: %w", err)
+		}
+		translations[key] = value
+	}
+	return translations, nil
+}
+
+// UpdateTranslations upserts translation strings for a language
+func (s *TranslationService) UpdateTranslations(lang string, data map[string]string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.Prepare(`INSERT INTO translations (key, language_code, value)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (key, language_code, context) DO UPDATE SET value = EXCLUDED.value`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare statement: %w", err)
+	}
+	defer stmt.Close()
+
+	for k, v := range data {
+		if _, err := stmt.Exec(k, lang, v); err != nil {
+			return fmt.Errorf("failed to upsert translation %s: %w", k, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit translations: %w", err)
+	}
+	return nil
+}

--- a/internal/services/workflow_service.go
+++ b/internal/services/workflow_service.go
@@ -1,0 +1,71 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+
+	"erp-backend/internal/database"
+	"erp-backend/internal/models"
+)
+
+// WorkflowService manages workflow approval requests
+type WorkflowService struct {
+	db *sql.DB
+}
+
+func NewWorkflowService() *WorkflowService {
+	return &WorkflowService{db: database.GetDB()}
+}
+
+// GetPendingRequests retrieves all workflow approvals with status PENDING
+func (s *WorkflowService) GetPendingRequests() ([]models.WorkflowRequest, error) {
+	rows, err := s.db.Query(`SELECT approval_id, state_id, approver_role_id, status, remarks, approved_at FROM workflow_approvals WHERE status = 'PENDING'`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get workflow requests: %w", err)
+	}
+	defer rows.Close()
+
+	var requests []models.WorkflowRequest
+	for rows.Next() {
+		var r models.WorkflowRequest
+		if err := rows.Scan(&r.ApprovalID, &r.StateID, &r.ApproverRoleID, &r.Status, &r.Remarks, &r.ApprovedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan workflow request: %w", err)
+		}
+		requests = append(requests, r)
+	}
+	return requests, nil
+}
+
+// CreateRequest inserts a new workflow approval request
+func (s *WorkflowService) CreateRequest(req *models.CreateWorkflowRequest) (*models.WorkflowRequest, error) {
+	var id int
+	err := s.db.QueryRow(`INSERT INTO workflow_approvals (state_id, approver_role_id, status) VALUES ($1, $2, 'PENDING') RETURNING approval_id`, req.StateID, req.ApproverRoleID).Scan(&id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create workflow request: %w", err)
+	}
+
+	return &models.WorkflowRequest{
+		ApprovalID:     id,
+		StateID:        req.StateID,
+		ApproverRoleID: req.ApproverRoleID,
+		Status:         "PENDING",
+	}, nil
+}
+
+// ApproveRequest marks a workflow request as approved
+func (s *WorkflowService) ApproveRequest(id int, remarks *string) error {
+	_, err := s.db.Exec(`UPDATE workflow_approvals SET status = 'APPROVED', remarks = $1, approved_at = NOW() WHERE approval_id = $2`, remarks, id)
+	if err != nil {
+		return fmt.Errorf("failed to approve workflow request: %w", err)
+	}
+	return nil
+}
+
+// RejectRequest marks a workflow request as rejected
+func (s *WorkflowService) RejectRequest(id int, remarks *string) error {
+	_, err := s.db.Exec(`UPDATE workflow_approvals SET status = 'REJECTED', remarks = $1, approved_at = NOW() WHERE approval_id = $2`, remarks, id)
+	if err != nil {
+		return fmt.Errorf("failed to reject workflow request: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- add workflow approval request API and service
- manage system settings, translations, audit logs, and printing endpoints
- wire new routes for configuration and approvals

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e20ea6bfc832ca6f34b6a70b5568d