### PR TITLE
Add dashboard metrics and quick action endpoints

### DIFF
--- a/internal/handlers/dashboard.go
+++ b/internal/handlers/dashboard.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"erp-backend/internal/services"
+	"erp-backend/internal/utils"
+
+	"github.com/gin-gonic/gin"
+)
+
+// DashboardHandler handles dashboard related endpoints
+
+type DashboardHandler struct {
+	dashboardService *services.DashboardService
+}
+
+// NewDashboardHandler creates a new DashboardHandler
+func NewDashboardHandler() *DashboardHandler {
+	return &DashboardHandler{
+		dashboardService: services.NewDashboardService(),
+	}
+}
+
+// GET /dashboard/metrics
+func (h *DashboardHandler) GetMetrics(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	locationID := c.GetInt("location_id")
+
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	if locParam := c.Query("location_id"); locParam != "" {
+		if id, err := strconv.Atoi(locParam); err == nil {
+			locationID = id
+		}
+	}
+
+	if locationID == 0 {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Location ID required", nil)
+		return
+	}
+
+	metrics, err := h.dashboardService.GetMetrics(companyID, locationID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get metrics", err)
+		return
+	}
+
+	utils.SuccessResponse(c, "Dashboard metrics retrieved successfully", metrics)
+}
+
+// GET /dashboard/quick-actions
+func (h *DashboardHandler) GetQuickActions(c *gin.Context) {
+	companyID := c.GetInt("company_id")
+	locationID := c.GetInt("location_id")
+
+	if companyID == 0 {
+		utils.ForbiddenResponse(c, "Company access required")
+		return
+	}
+
+	if locParam := c.Query("location_id"); locParam != "" {
+		if id, err := strconv.Atoi(locParam); err == nil {
+			locationID = id
+		}
+	}
+
+	if locationID == 0 {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Location ID required", nil)
+		return
+	}
+
+	counts, err := h.dashboardService.GetQuickActionCounts(companyID, locationID)
+	if err != nil {
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get quick actions", err)
+		return
+	}
+
+	utils.SuccessResponse(c, "Quick action counts retrieved successfully", counts)
+}

--- a/internal/models/dashboard.go
+++ b/internal/models/dashboard.go
@@ -1,0 +1,22 @@
+package models
+
+// DashboardMetrics represents summarized metrics for dashboard
+// includes credit outstanding, inventory value, today's totals and cash summary
+
+type DashboardMetrics struct {
+	CreditOutstanding float64 `json:"credit_outstanding"`
+	InventoryValue    float64 `json:"inventory_value"`
+	TodaySales        float64 `json:"today_sales"`
+	TodayPurchases    float64 `json:"today_purchases"`
+	CashIn            float64 `json:"cash_in"`
+	CashOut           float64 `json:"cash_out"`
+}
+
+// QuickActionCounts represents counts for quick dashboard actions
+
+type QuickActionCounts struct {
+	SalesToday       int `json:"sales_today"`
+	PurchasesToday   int `json:"purchases_today"`
+	CollectionsToday int `json:"collections_today"`
+	LowStockItems    int `json:"low_stock_items"`
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -44,6 +44,7 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 	workflowHandler := handlers.NewWorkflowHandler()
 	settingsHandler := handlers.NewSettingsHandler()
 	auditLogHandler := handlers.NewAuditLogHandler()
+	dashboardHandler := handlers.NewDashboardHandler()
 	translationHandler := handlers.NewTranslationHandler()
 	printHandler := handlers.NewPrintHandler()
 	// Health check endpoint
@@ -76,6 +77,14 @@ func Initialize(router *gin.Engine, db *sql.DB) {
 			{
 				authProtected.GET("/me", authHandler.GetMe)
 				authProtected.POST("/logout", authHandler.Logout)
+			}
+
+			// Dashboard routes
+			dashboard := protected.Group("/dashboard")
+			dashboard.Use(middleware.RequireCompanyAccess())
+			{
+				dashboard.GET("/metrics", middleware.RequirePermission("VIEW_DASHBOARD"), dashboardHandler.GetMetrics)
+				dashboard.GET("/quick-actions", middleware.RequirePermission("VIEW_DASHBOARD"), dashboardHandler.GetQuickActions)
 			}
 
 			// User management routes

--- a/internal/services/dashboard_service.go
+++ b/internal/services/dashboard_service.go
@@ -1,0 +1,154 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"erp-backend/internal/database"
+	"erp-backend/internal/models"
+)
+
+// DashboardService provides dashboard metrics and quick action counts
+
+type DashboardService struct {
+	db *sql.DB
+}
+
+// NewDashboardService creates a new DashboardService
+func NewDashboardService() *DashboardService {
+	return &DashboardService{db: database.GetDB()}
+}
+
+// GetMetrics aggregates various metrics for dashboard
+func (s *DashboardService) GetMetrics(companyID, locationID int) (*models.DashboardMetrics, error) {
+	metrics := &models.DashboardMetrics{}
+
+	// Credit outstanding from sales
+	if err := s.db.QueryRow(`
+                SELECT COALESCE(SUM(s.total_amount - s.paid_amount),0)
+                FROM sales s
+                JOIN locations l ON s.location_id = l.location_id
+                WHERE l.company_id = $1 AND s.location_id = $2 AND s.is_deleted = FALSE`,
+		companyID, locationID).Scan(&metrics.CreditOutstanding); err != nil {
+		return nil, fmt.Errorf("failed to get credit outstanding: %w", err)
+	}
+
+	// Inventory value
+	if err := s.db.QueryRow(`
+                SELECT COALESCE(SUM(st.quantity * COALESCE(p.cost_price,0)),0)
+                FROM stock st
+                JOIN locations l ON st.location_id = l.location_id
+                JOIN products p ON st.product_id = p.product_id
+                WHERE l.company_id = $1 AND st.location_id = $2`,
+		companyID, locationID).Scan(&metrics.InventoryValue); err != nil {
+		return nil, fmt.Errorf("failed to get inventory value: %w", err)
+	}
+
+	today := time.Now().Format("2006-01-02")
+
+	// Today's sales
+	if err := s.db.QueryRow(`
+                SELECT COALESCE(SUM(s.total_amount),0)
+                FROM sales s
+                JOIN locations l ON s.location_id = l.location_id
+                WHERE l.company_id = $1 AND s.location_id = $2 AND s.sale_date = $3 AND s.is_deleted = FALSE`,
+		companyID, locationID, today).Scan(&metrics.TodaySales); err != nil {
+		return nil, fmt.Errorf("failed to get today's sales: %w", err)
+	}
+
+	// Today's purchases
+	if err := s.db.QueryRow(`
+                SELECT COALESCE(SUM(p.total_amount),0)
+                FROM purchases p
+                JOIN locations l ON p.location_id = l.location_id
+                WHERE l.company_id = $1 AND p.location_id = $2 AND p.purchase_date = $3 AND p.is_deleted = FALSE`,
+		companyID, locationID, today).Scan(&metrics.TodayPurchases); err != nil {
+		return nil, fmt.Errorf("failed to get today's purchases: %w", err)
+	}
+
+	var salesPaid, collectionsAmount float64
+
+	// Cash in from sales
+	if err := s.db.QueryRow(`
+                SELECT COALESCE(SUM(s.paid_amount),0)
+                FROM sales s
+                JOIN locations l ON s.location_id = l.location_id
+                WHERE l.company_id = $1 AND s.location_id = $2 AND s.sale_date = $3 AND s.is_deleted = FALSE`,
+		companyID, locationID, today).Scan(&salesPaid); err != nil {
+		return nil, fmt.Errorf("failed to get sales payments: %w", err)
+	}
+
+	// Cash in from collections
+	if err := s.db.QueryRow(`
+                SELECT COALESCE(SUM(c.amount),0)
+                FROM collections c
+                JOIN customers cu ON c.customer_id = cu.customer_id
+                WHERE cu.company_id = $1 AND c.location_id = $2 AND c.collection_date = $3`,
+		companyID, locationID, today).Scan(&collectionsAmount); err != nil {
+		return nil, fmt.Errorf("failed to get collections: %w", err)
+	}
+
+	metrics.CashIn = salesPaid + collectionsAmount
+
+	// Cash out from purchases
+	if err := s.db.QueryRow(`
+                SELECT COALESCE(SUM(p.paid_amount),0)
+                FROM purchases p
+                JOIN locations l ON p.location_id = l.location_id
+                WHERE l.company_id = $1 AND p.location_id = $2 AND p.purchase_date = $3 AND p.is_deleted = FALSE`,
+		companyID, locationID, today).Scan(&metrics.CashOut); err != nil {
+		return nil, fmt.Errorf("failed to get cash out: %w", err)
+	}
+
+	return metrics, nil
+}
+
+// GetQuickActionCounts returns counts for quick actions on dashboard
+func (s *DashboardService) GetQuickActionCounts(companyID, locationID int) (*models.QuickActionCounts, error) {
+	counts := &models.QuickActionCounts{}
+	today := time.Now().Format("2006-01-02")
+
+	// Sales today
+	if err := s.db.QueryRow(`
+                SELECT COUNT(*)
+                FROM sales s
+                JOIN locations l ON s.location_id = l.location_id
+                WHERE l.company_id = $1 AND s.location_id = $2 AND s.sale_date = $3 AND s.is_deleted = FALSE`,
+		companyID, locationID, today).Scan(&counts.SalesToday); err != nil {
+		return nil, fmt.Errorf("failed to get sales count: %w", err)
+	}
+
+	// Purchases today
+	if err := s.db.QueryRow(`
+                SELECT COUNT(*)
+                FROM purchases p
+                JOIN locations l ON p.location_id = l.location_id
+                WHERE l.company_id = $1 AND p.location_id = $2 AND p.purchase_date = $3 AND p.is_deleted = FALSE`,
+		companyID, locationID, today).Scan(&counts.PurchasesToday); err != nil {
+		return nil, fmt.Errorf("failed to get purchases count: %w", err)
+	}
+
+	// Collections today
+	if err := s.db.QueryRow(`
+                SELECT COUNT(*)
+                FROM collections c
+                JOIN customers cu ON c.customer_id = cu.customer_id
+                WHERE cu.company_id = $1 AND c.location_id = $2 AND c.collection_date = $3`,
+		companyID, locationID, today).Scan(&counts.CollectionsToday); err != nil {
+		return nil, fmt.Errorf("failed to get collections count: %w", err)
+	}
+
+	// Low stock items
+	if err := s.db.QueryRow(`
+                SELECT COUNT(*)
+                FROM stock st
+                JOIN locations l ON st.location_id = l.location_id
+                JOIN products p ON st.product_id = p.product_id
+                WHERE l.company_id = $1 AND st.location_id = $2 AND st.quantity <= p.reorder_level`,
+		companyID, locationID).Scan(&counts.LowStockItems); err != nil {
+		return nil, fmt.Errorf("failed to get low stock count: %w", err)
+	}
+
+	return counts, nil
+}


### PR DESCRIPTION
## Summary
- add dashboard models, handler, service for metrics and quick actions
- expose `/dashboard/metrics` and `/dashboard/quick-actions` protected routes
- aggregate sales, purchases, collections, and inventory for summary data

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e271c5618832c9e83217090397733