### PR TITLE
Use strings.Join for multi-field updates

### DIFF
--- a/internal/services/company_service.go
+++ b/internal/services/company_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"erp-backend/internal/database"
 	"erp-backend/internal/models"
@@ -199,11 +200,10 @@ func (s *CompanyService) UpdateCompany(companyID int, req *models.UpdateCompanyR
 		return fmt.Errorf("no fields to update")
 	}
 
-	argCount++
 	setParts = append(setParts, "updated_at = CURRENT_TIMESTAMP")
 
 	query := fmt.Sprintf("UPDATE companies SET %s WHERE company_id = $%d",
-		fmt.Sprintf("%s", setParts), argCount)
+		strings.Join(setParts, ", "), argCount+1)
 	args = append(args, companyID)
 
 	result, err := s.db.Exec(query, args...)

--- a/internal/services/location_service.go
+++ b/internal/services/location_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"erp-backend/internal/database"
 	"erp-backend/internal/models"
@@ -146,11 +147,10 @@ func (s *LocationService) UpdateLocation(locationID int, req *models.UpdateLocat
 		return fmt.Errorf("no fields to update")
 	}
 
-	argCount++
 	setParts = append(setParts, "updated_at = CURRENT_TIMESTAMP")
 
 	query := fmt.Sprintf("UPDATE locations SET %s WHERE location_id = $%d",
-		fmt.Sprintf("%s", setParts), argCount)
+		strings.Join(setParts, ", "), argCount+1)
 	args = append(args, locationID)
 
 	result, err := s.db.Exec(query, args...)

--- a/internal/services/location_service_test.go
+++ b/internal/services/location_service_test.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	"erp-backend/internal/models"
+)
+
+var lastExec struct {
+	query string
+	args  []driver.NamedValue
+}
+
+type mockDriver struct{}
+
+func (d *mockDriver) Open(name string) (driver.Conn, error) {
+	return &mockConn{}, nil
+}
+
+type mockConn struct{}
+
+func (c *mockConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+func (c *mockConn) Close() error              { return nil }
+func (c *mockConn) Begin() (driver.Tx, error) { return nil, errors.New("not implemented") }
+
+func (c *mockConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	lastExec.query = query
+	lastExec.args = append([]driver.NamedValue(nil), args...)
+	return mockResult{}, nil
+}
+
+type mockResult struct{}
+
+func (r mockResult) LastInsertId() (int64, error) { return 0, nil }
+func (r mockResult) RowsAffected() (int64, error) { return 1, nil }
+
+func TestUpdateLocationMultipleFields(t *testing.T) {
+	sql.Register("mock", &mockDriver{})
+	db, err := sql.Open("mock", "")
+	if err != nil {
+		t.Fatalf("failed to open mock db: %v", err)
+	}
+	svc := &LocationService{db: db}
+
+	name := "New Name"
+	phone := "123456"
+	req := &models.UpdateLocationRequest{
+		Name:  &name,
+		Phone: &phone,
+	}
+
+	lastExec.query = ""
+	lastExec.args = nil
+
+	err = svc.UpdateLocation(1, req)
+	if err != nil {
+		t.Fatalf("UpdateLocation returned error: %v", err)
+	}
+
+	expectedQuery := "UPDATE locations SET name = $1, phone = $2, updated_at = CURRENT_TIMESTAMP WHERE location_id = $3"
+	if lastExec.query != expectedQuery {
+		t.Fatalf("unexpected query: got %q, want %q", lastExec.query, expectedQuery)
+	}
+
+	if len(lastExec.args) != 3 ||
+		lastExec.args[0].Value != name ||
+		lastExec.args[1].Value != phone ||
+		lastExec.args[2].Value != int64(1) && lastExec.args[2].Value != 1 {
+		t.Fatalf("unexpected args: %#v", lastExec.args)
+	}
+}

--- a/internal/services/loyalty_service.go
+++ b/internal/services/loyalty_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"erp-backend/internal/database"
@@ -457,11 +458,10 @@ func (s *LoyaltyService) UpdatePromotion(promotionID, companyID int, req *models
 		return fmt.Errorf("no fields to update")
 	}
 
-	argCount++
 	setParts = append(setParts, "updated_at = CURRENT_TIMESTAMP")
 
 	query := fmt.Sprintf("UPDATE promotions SET %s WHERE promotion_id = $%d",
-		fmt.Sprintf("%s", setParts), argCount)
+		strings.Join(setParts, ", "), argCount+1)
 	args = append(args, promotionID)
 
 	result, err := s.db.Exec(query, args...)

--- a/internal/services/purchase_service.go
+++ b/internal/services/purchase_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"erp-backend/internal/database"
@@ -631,7 +632,7 @@ func (s *PurchaseService) UpdatePurchase(purchaseID, companyID, userID int, req 
 
 		argCount++
 		query := fmt.Sprintf("UPDATE purchases SET %s WHERE purchase_id = $%d",
-			fmt.Sprintf("%s", updates), argCount)
+			strings.Join(updates, ", "), argCount)
 		args = append(args, purchaseID)
 
 		_, err = tx.Exec(query, args...)

--- a/internal/services/role_service.go
+++ b/internal/services/role_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"erp-backend/internal/database"
 	"erp-backend/internal/models"
@@ -142,7 +143,7 @@ func (s *RoleService) UpdateRole(roleID int, req *models.UpdateRoleRequest) erro
 
 	argCount++
 	query := fmt.Sprintf("UPDATE roles SET %s WHERE role_id = $%d",
-		fmt.Sprintf("%s", setParts), argCount)
+		strings.Join(setParts, ", "), argCount)
 	args = append(args, roleID)
 
 	result, err := s.db.Exec(query, args...)

--- a/internal/services/supplier_service.go
+++ b/internal/services/supplier_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"erp-backend/internal/database"
@@ -287,7 +288,7 @@ func (s *SupplierService) UpdateSupplier(supplierID, companyID int, req *models.
 	// Add WHERE clause
 	argCount++
 	query := fmt.Sprintf("UPDATE suppliers SET %s WHERE supplier_id = $%d",
-		fmt.Sprintf("%s", updates), argCount)
+		strings.Join(updates, ", "), argCount)
 	args = append(args, supplierID)
 
 	_, err = s.db.Exec(query, args...)

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"erp-backend/internal/database"
 	"erp-backend/internal/models"
@@ -178,11 +179,10 @@ func (s *UserService) UpdateUser(userID int, req *models.UpdateUserRequest) erro
 		return fmt.Errorf("no fields to update")
 	}
 
-	argCount++
-	setParts = append(setParts, fmt.Sprintf("updated_at = CURRENT_TIMESTAMP"))
+	setParts = append(setParts, "updated_at = CURRENT_TIMESTAMP")
 
 	query := fmt.Sprintf("UPDATE users SET %s WHERE user_id = $%d",
-		fmt.Sprintf("%s", setParts), argCount)
+		strings.Join(setParts, ", "), argCount+1)
 	args = append(args, userID)
 
 	result, err := s.db.Exec(query, args...)


### PR DESCRIPTION
## Summary
- build SQL update clauses with `strings.Join` instead of `fmt.Sprintf` to avoid bracketed slice representation
- adjust arg counters for update placeholders across services
- add unit test ensuring multi-field location updates build correct SQL

## Testing
- `GOPROXY=direct go test ./internal/services -run TestUpdateLocationMultipleFields -count=1`
- `go mod tidy` *(fails: github.com/stretchr/testify/assert: Get "https://proxy.golang.org/github.com/stretchr/testify/@v/v1.10.0.zip": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f713d9460832cb173e482ffe5026a