### PR TITLE
Add product-based promotion eligibility

### DIFF
--- a/internal/services/loyalty_service_test.go
+++ b/internal/services/loyalty_service_test.go
@@ -1,0 +1,84 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"erp-backend/internal/models"
+)
+
+func TestCheckPromotionEligibility_ProductSpecificPromotion(t *testing.T) {
+	start := time.Now().Add(-time.Hour)
+	end := time.Now().Add(time.Hour)
+	cond := models.JSONB{"product_ids": []interface{}{1, 2}}
+	promo := models.Promotion{
+		PromotionID:  1,
+		CompanyID:    1,
+		Name:         "Promo",
+		DiscountType: func() *string { s := "PERCENTAGE"; return &s }(),
+		Value:        func() *float64 { v := 10.0; return &v }(),
+		StartDate:    start,
+		EndDate:      end,
+		ApplicableTo: func() *string { s := "PRODUCTS"; return &s }(),
+		Conditions:   &cond,
+		IsActive:     true,
+	}
+
+	s := &LoyaltyService{}
+	orig := getPromotions
+	defer func() { getPromotions = orig }()
+	getPromotions = func(_ *LoyaltyService, companyID int, activeOnly bool) ([]models.Promotion, error) {
+		return []models.Promotion{promo}, nil
+	}
+
+	req := &models.PromotionEligibilityRequest{TotalAmount: 100, ProductIDs: []int{1}}
+
+	resp, err := s.CheckPromotionEligibility(1, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.EligiblePromotions) != 1 {
+		t.Fatalf("expected 1 promotion, got %d", len(resp.EligiblePromotions))
+	}
+	if resp.TotalDiscount != 10 {
+		t.Fatalf("expected discount 10, got %f", resp.TotalDiscount)
+	}
+}
+
+func TestCheckPromotionEligibility_ProductSpecificPromotion_NotEligible(t *testing.T) {
+	start := time.Now().Add(-time.Hour)
+	end := time.Now().Add(time.Hour)
+	cond := models.JSONB{"product_ids": []interface{}{1, 2}}
+	promo := models.Promotion{
+		PromotionID:  1,
+		CompanyID:    1,
+		Name:         "Promo",
+		DiscountType: func() *string { s := "PERCENTAGE"; return &s }(),
+		Value:        func() *float64 { v := 10.0; return &v }(),
+		StartDate:    start,
+		EndDate:      end,
+		ApplicableTo: func() *string { s := "PRODUCTS"; return &s }(),
+		Conditions:   &cond,
+		IsActive:     true,
+	}
+
+	s := &LoyaltyService{}
+	orig := getPromotions
+	defer func() { getPromotions = orig }()
+	getPromotions = func(_ *LoyaltyService, companyID int, activeOnly bool) ([]models.Promotion, error) {
+		return []models.Promotion{promo}, nil
+	}
+
+	req := &models.PromotionEligibilityRequest{TotalAmount: 100, ProductIDs: []int{3}}
+
+	resp, err := s.CheckPromotionEligibility(1, req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.EligiblePromotions) != 0 {
+		t.Fatalf("expected 0 promotions, got %d", len(resp.EligiblePromotions))
+	}
+	if resp.TotalDiscount != 0 {
+		t.Fatalf("expected discount 0, got %f", resp.TotalDiscount)
+	}
+}

--- a/internal/services/sales_service.go
+++ b/internal/services/sales_service.go
@@ -299,7 +299,20 @@ func (s *SalesService) CreateSale(companyID, locationID, userID int, req *models
 		eligibilityReq := &models.PromotionEligibilityRequest{
 			CustomerID:  req.CustomerID,
 			TotalAmount: subtotal,
-			ProductIDs:  []int{}, // TODO: Extract product IDs from items
+			ProductIDs:  []int{},
+		}
+
+		productIDSet := make(map[int]struct{})
+		for _, item := range req.Items {
+			if item.ProductID == nil {
+				continue
+			}
+			id := *item.ProductID
+			if _, exists := productIDSet[id]; exists {
+				continue
+			}
+			productIDSet[id] = struct{}{}
+			eligibilityReq.ProductIDs = append(eligibilityReq.ProductIDs, id)
 		}
 
 		eligibility, err := loyaltyService.CheckPromotionEligibility(companyID, eligibilityReq)


### PR DESCRIPTION
## Summary
- gather and deduplicate product IDs before promotion checks
- support product-specific promotions in eligibility logic
- test promotion eligibility for matching and non-matching products

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689f75769af4832c92d88950bbefa8d7