### PR TITLE
Track ledger entry creators and updaters

### DIFF
--- a/Docs & Schema/PostgrSQL.sql
+++ b/Docs & Schema/PostgrSQL.sql
@@ -673,6 +673,8 @@ CREATE TABLE ledger_entries (
     transaction_type VARCHAR(50),
     transaction_id INTEGER,
     description TEXT,
+    created_by INT NOT NULL REFERENCES users(user_id),
+    updated_by INT REFERENCES users(user_id),
     sync_status VARCHAR(20) DEFAULT 'synced',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/internal/models/ledger.go
+++ b/internal/models/ledger.go
@@ -8,6 +8,8 @@ type LedgerEntry struct {
 	Credit      float64 `json:"credit" db:"credit"`
 	Reference   string  `json:"reference" db:"reference"`
 	Description *string `json:"description,omitempty" db:"description"`
+	CreatedBy   int     `json:"created_by" db:"created_by"`
+	UpdatedBy   *int    `json:"updated_by,omitempty" db:"updated_by"`
 	SyncModel
 }
 

--- a/internal/services/expense_service.go
+++ b/internal/services/expense_service.go
@@ -25,7 +25,7 @@ func (s *ExpenseService) CreateExpense(companyID, locationID, userID int, req *m
 		return 0, fmt.Errorf("failed to create expense: %w", err)
 	}
 	ledger := NewLedgerService()
-	_ = ledger.RecordExpense(companyID, id, req.Amount)
+	_ = ledger.RecordExpense(companyID, id, req.Amount, userID)
 	return id, nil
 }
 

--- a/internal/services/ledger_service.go
+++ b/internal/services/ledger_service.go
@@ -16,21 +16,20 @@ func NewLedgerService() *LedgerService {
 }
 
 // RecordExpense creates ledger entries for an expense
-func (s *LedgerService) RecordExpense(companyID, expenseID int, amount float64) error {
-	// Placeholder implementation
-	_, err := s.db.Exec(`INSERT INTO ledger_entries (company_id, reference, debit) VALUES ($1,$2,$3)`, companyID, expenseID, amount)
+func (s *LedgerService) RecordExpense(companyID, expenseID int, amount float64, userID int) error {
+	_, err := s.db.Exec(`INSERT INTO ledger_entries (company_id, reference, debit, created_by, updated_by) VALUES ($1,$2,$3,$4,$4)`, companyID, expenseID, amount, userID)
 	return err
 }
 
 // RecordSale creates ledger entries for a sale
-func (s *LedgerService) RecordSale(companyID, saleID int, amount float64) error {
-	_, err := s.db.Exec(`INSERT INTO ledger_entries (company_id, reference, credit) VALUES ($1,$2,$3)`, companyID, saleID, amount)
+func (s *LedgerService) RecordSale(companyID, saleID int, amount float64, userID int) error {
+	_, err := s.db.Exec(`INSERT INTO ledger_entries (company_id, reference, credit, created_by, updated_by) VALUES ($1,$2,$3,$4,$4)`, companyID, saleID, amount, userID)
 	return err
 }
 
 // RecordPurchase creates ledger entries for a purchase
-func (s *LedgerService) RecordPurchase(companyID, purchaseID int, amount float64) error {
-	_, err := s.db.Exec(`INSERT INTO ledger_entries (company_id, reference, debit) VALUES ($1,$2,$3)`, companyID, purchaseID, amount)
+func (s *LedgerService) RecordPurchase(companyID, purchaseID int, amount float64, userID int) error {
+	_, err := s.db.Exec(`INSERT INTO ledger_entries (company_id, reference, debit, created_by, updated_by) VALUES ($1,$2,$3,$4,$4)`, companyID, purchaseID, amount, userID)
 	return err
 }
 

--- a/internal/services/purchase_service.go
+++ b/internal/services/purchase_service.go
@@ -362,7 +362,7 @@ func (s *PurchaseService) CreatePurchase(companyID, locationID, userID int, req 
 	}
 
 	ledgerService := NewLedgerService()
-	_ = ledgerService.RecordPurchase(companyID, purchase.PurchaseID, totalAmount)
+	_ = ledgerService.RecordPurchase(companyID, purchase.PurchaseID, totalAmount, userID)
 
 	// Set response data
 	purchase.PurchaseNumber = purchaseNumber

--- a/internal/services/sales_service.go
+++ b/internal/services/sales_service.go
@@ -481,7 +481,7 @@ func (s *SalesService) CreateSale(companyID, locationID, userID int, req *models
 
 	// Record ledger entry
 	ledgerService := NewLedgerService()
-	_ = ledgerService.RecordSale(companyID, saleID, totalAmount)
+	_ = ledgerService.RecordSale(companyID, saleID, totalAmount, userID)
 
 	// Award loyalty points if customer is provided (async operation)
 	if req.CustomerID != nil {

--- a/internal/services/voucher_service.go
+++ b/internal/services/voucher_service.go
@@ -27,9 +27,9 @@ func (s *VoucherService) CreateVoucher(companyID, userID int, vType string, req 
 	ledger := NewLedgerService()
 	switch vType {
 	case "payment":
-		_ = ledger.RecordExpense(companyID, id, req.Amount)
+		_ = ledger.RecordExpense(companyID, id, req.Amount, userID)
 	case "receipt":
-		_ = ledger.RecordSale(companyID, id, req.Amount)
+		_ = ledger.RecordSale(companyID, id, req.Amount, userID)
 	case "journal":
 		// Placeholder for journal entries
 	}

--- a/migrations/002_add_created_updated_by_to_ledger_entries.sql
+++ b/migrations/002_add_created_updated_by_to_ledger_entries.sql
@@ -1,0 +1,6 @@
+ALTER TABLE ledger_entries
+    ADD COLUMN created_by INTEGER REFERENCES users(user_id);
+ALTER TABLE ledger_entries
+    ADD COLUMN updated_by INTEGER REFERENCES users(user_id);
+UPDATE ledger_entries SET created_by = 1, updated_by = 1 WHERE created_by IS NULL;
+ALTER TABLE ledger_entries ALTER COLUMN created_by SET NOT NULL;


### PR DESCRIPTION
## Summary
- add created_by and updated_by columns to ledger_entries with migration
- record acting user when creating ledger entries in services
- expose CreatedBy and UpdatedBy on LedgerEntry model

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a1f43df9ac832cad7dd50b6c7fbfdf