### PR TITLE
Load CORS settings from config

### DIFF
--- a/go_backend_rmt/cmd/server/main.go
+++ b/go_backend_rmt/cmd/server/main.go
@@ -39,10 +39,10 @@ func main() {
 	// Apply global middleware
 	router.Use(middleware.Logger())
 	router.Use(middleware.Recovery())
-	router.Use(middleware.CORS())
+	router.Use(middleware.CORS(cfg))
 
 	// Initialize routes
-	routes.Initialize(router)
+	routes.Initialize(router, cfg)
 
 	// Start server
 	port := os.Getenv("PORT")

--- a/go_backend_rmt/internal/middleware/cors.go
+++ b/go_backend_rmt/internal/middleware/cors.go
@@ -2,19 +2,24 @@ package middleware
 
 import (
 	"net/http"
+	"strings"
+
+	"erp-backend/internal/config"
 
 	"github.com/gin-gonic/gin"
 )
 
 // CORS middleware handles Cross-Origin Resource Sharing
-func CORS() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		c.Request.Header.Get("Origin")
+func CORS(cfg *config.Config) gin.HandlerFunc {
+	allowedOrigins := strings.Join(cfg.AllowedOrigins, ", ")
+	allowedMethods := strings.Join(cfg.AllowedMethods, ", ")
+	allowedHeaders := strings.Join(cfg.AllowedHeaders, ", ")
 
+	return func(c *gin.Context) {
 		// Add CORS headers
-		c.Header("Access-Control-Allow-Origin", "*") // Configure based on your needs
-		c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		c.Header("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+		c.Header("Access-Control-Allow-Origin", allowedOrigins)
+		c.Header("Access-Control-Allow-Methods", allowedMethods)
+		c.Header("Access-Control-Allow-Headers", allowedHeaders)
 		c.Header("Access-Control-Expose-Headers", "Content-Length, X-Total-Count")
 		c.Header("Access-Control-Allow-Credentials", "true")
 		c.Header("Access-Control-Max-Age", "86400")

--- a/go_backend_rmt/internal/routes/routes.go
+++ b/go_backend_rmt/internal/routes/routes.go
@@ -11,8 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func Initialize(router *gin.Engine) {
-	cfg := config.Load()
+func Initialize(router *gin.Engine, cfg *config.Config) {
 
 	// Initialize JWT utils
 	utils.InitializeJWT(cfg.JWTSecret)


### PR DESCRIPTION
## Summary
- read CORS allowed origins, methods and headers from configuration
- remove unused Origin header lookup
- propagate configuration to router setup

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a3511c2580832c996fbd5da36b4333