### PR TITLE
Use numeric string for JWT subject

### DIFF
--- a/go_backend_rmt/internal/utils/jwt.go
+++ b/go_backend_rmt/internal/utils/jwt.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"strconv"
 	"time"
 
 	"erp-backend/internal/models"
@@ -36,7 +37,7 @@ func GenerateAccessToken(user *models.User, sessionID string, expiry time.Durati
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(expiry)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
-			Subject:   string(rune(user.UserID)),
+			Subject:   strconv.Itoa(user.UserID),
 		},
 	}
 
@@ -59,7 +60,7 @@ func GenerateRefreshToken(user *models.User, sessionID string, expiry time.Durat
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(expiry)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
-			Subject:   string(rune(user.UserID)),
+			Subject:   strconv.Itoa(user.UserID),
 		},
 	}
 

--- a/go_backend_rmt/internal/utils/jwt_test.go
+++ b/go_backend_rmt/internal/utils/jwt_test.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"erp-backend/internal/models"
+)
+
+func TestGenerateAccessToken_SubjectIsNumeric(t *testing.T) {
+	InitializeJWT("test-secret")
+	user := &models.User{UserID: 123, Email: "user@example.com"}
+	token, err := GenerateAccessToken(user, "sess", time.Minute)
+	if err != nil {
+		t.Fatalf("GenerateAccessToken returned error: %v", err)
+	}
+	claims, err := ValidateToken(token)
+	if err != nil {
+		t.Fatalf("ValidateToken returned error: %v", err)
+	}
+	expected := strconv.Itoa(user.UserID)
+	if claims.Subject != expected {
+		t.Fatalf("expected subject %s, got %s", expected, claims.Subject)
+	}
+}
+
+func TestGenerateRefreshToken_SubjectIsNumeric(t *testing.T) {
+	InitializeJWT("test-secret")
+	user := &models.User{UserID: 456, Email: "user@example.com"}
+	token, err := GenerateRefreshToken(user, "sess", time.Minute)
+	if err != nil {
+		t.Fatalf("GenerateRefreshToken returned error: %v", err)
+	}
+	claims, err := ValidateToken(token)
+	if err != nil {
+		t.Fatalf("ValidateToken returned error: %v", err)
+	}
+	expected := strconv.Itoa(user.UserID)
+	if claims.Subject != expected {
+		t.Fatalf("expected subject %s, got %s", expected, claims.Subject)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure JWT `sub` claim stores user ID as a numeric string
- add tests confirming `sub` in access and refresh tokens reflects the user ID

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a35193b894832ca873a8b1f345dc6f