### PR TITLE
feat: add api client and service modules

### DIFF
--- a/next_frontend_web/.env.local
+++ b/next_frontend_web/.env.local
@@ -7,3 +7,7 @@ NEXT_PUBLIC_COUCHDB_PASSWORD=admin
 # NEXT_PUBLIC_COUCHDB_URL=https://your-couchdb-instance.com
 # NEXT_PUBLIC_COUCHDB_USERNAME=your_username
 # NEXT_PUBLIC_COUCHDB_PASSWORD=your_password
+
+# API base URL
+NEXT_PUBLIC_API_URL=http://localhost:8080/api/v1
+

--- a/next_frontend_web/src/services/apiClient.ts
+++ b/next_frontend_web/src/services/apiClient.ts
@@ -1,0 +1,60 @@
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '';
+
+interface RequestOptions extends RequestInit {
+  auth?: boolean;
+}
+
+async function request<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
+  const { auth = true, headers, body, ...rest } = options;
+
+  const config: RequestInit = {
+    ...rest,
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      ...(headers || {}),
+    },
+    body: body ? (typeof body === 'string' ? body : JSON.stringify(body)) : undefined,
+  };
+
+  if (auth && typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    if (token) {
+      (config.headers as Record<string, string>)['Authorization'] = `Bearer ${token}`;
+    }
+  }
+
+  const response = await fetch(`${API_BASE_URL}${endpoint}`, config);
+
+  if (!response.ok) {
+    let errorMessage = response.statusText;
+    try {
+      const errorData = await response.json();
+      errorMessage = errorData.message || errorMessage;
+    } catch (err) {
+      // ignore JSON parse errors
+    }
+    throw new Error(errorMessage);
+  }
+
+  if (response.status === 204) {
+    // No Content
+    return null as unknown as T;
+  }
+
+  return (await response.json()) as T;
+}
+
+const apiClient = {
+  get: <T>(url: string, options?: RequestOptions) => request<T>(url, { ...options, method: 'GET' }),
+  post: <T>(url: string, data?: any, options?: RequestOptions) =>
+    request<T>(url, { ...options, method: 'POST', body: data }),
+  put: <T>(url: string, data?: any, options?: RequestOptions) =>
+    request<T>(url, { ...options, method: 'PUT', body: data }),
+  patch: <T>(url: string, data?: any, options?: RequestOptions) =>
+    request<T>(url, { ...options, method: 'PATCH', body: data }),
+  delete: <T>(url: string, options?: RequestOptions) =>
+    request<T>(url, { ...options, method: 'DELETE' }),
+};
+
+export default apiClient;

--- a/next_frontend_web/src/services/auth.ts
+++ b/next_frontend_web/src/services/auth.ts
@@ -1,0 +1,26 @@
+import api from './apiClient';
+import { User, Company } from '../types';
+
+interface AuthResponse {
+  token: string;
+  user: User;
+  company: Company;
+}
+
+export const login = async (username: string, password: string): Promise<AuthResponse> => {
+  const data = await api.post<AuthResponse>('/auth/login', { username, password });
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('token', data.token);
+  }
+  return data;
+};
+
+export const register = async (payload: Record<string, any>): Promise<AuthResponse> => {
+  const data = await api.post<AuthResponse>('/auth/register', payload);
+  if (typeof window !== 'undefined') {
+    localStorage.setItem('token', data.token);
+  }
+  return data;
+};
+
+export const getProfile = () => api.get<User>('/auth/me');

--- a/next_frontend_web/src/services/index.ts
+++ b/next_frontend_web/src/services/index.ts
@@ -1,0 +1,3 @@
+export { default as apiClient } from './apiClient';
+export * as auth from './auth';
+export * as products from './products';

--- a/next_frontend_web/src/services/products.ts
+++ b/next_frontend_web/src/services/products.ts
@@ -1,0 +1,9 @@
+import api from './apiClient';
+import { Product } from '../types';
+
+export const getProducts = () => api.get<Product[]>('/products');
+export const getProduct = (id: string) => api.get<Product>(`/products/${id}`);
+export const createProduct = (payload: Partial<Product>) => api.post<Product>('/products', payload);
+export const updateProduct = (id: string, payload: Partial<Product>) =>
+  api.put<Product>(`/products/${id}`, payload);
+export const deleteProduct = (id: string) => api.delete<void>(`/products/${id}`);


### PR DESCRIPTION
## Summary
- add configurable API client with JSON/error handling and auth token support
- wrap auth and product endpoints in service helpers
- document API base URL in example env file

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a362aeb3a8832c97f370d48da77141