### PR TITLE
refactor: replace local data with service calls

### DIFF
--- a/next_frontend_web/src/components/ERP/Common/CategoryList.tsx
+++ b/next_frontend_web/src/components/ERP/Common/CategoryList.tsx
@@ -102,7 +102,7 @@ const CategoryAddDialog: React.FC<{
 };
 
 const CategoryList: React.FC = () => {
-  const { state, dispatch } = useApp();
+  const { state, dispatch, createCategory } = useApp();
   const [searchTerm, setSearchTerm] = useState('');
   const [showCategoryDropdown, setShowCategoryDropdown] = useState(false);
   const [showCategoryDialog, setShowCategoryDialog] = useState(false);
@@ -126,10 +126,14 @@ const CategoryList: React.FC = () => {
     setShowCategoryDropdown(false);
   };
 
-  const handleSaveCategory = (categoryName: string) => {
+  const handleSaveCategory = async (categoryName: string) => {
     if (!state.categories.includes(categoryName)) {
-      dispatch({ type: 'ADD_CATEGORY', payload: categoryName });
-      dispatch({ type: 'SET_CATEGORY', payload: categoryName });
+      try {
+        await createCategory({ name: categoryName });
+        dispatch({ type: 'SET_CATEGORY', payload: categoryName });
+      } catch (error) {
+        console.error('Error saving category:', error);
+      }
     }
   };
 

--- a/next_frontend_web/src/components/ERP/Common/ProductGrid.tsx
+++ b/next_frontend_web/src/components/ERP/Common/ProductGrid.tsx
@@ -242,7 +242,7 @@ const ProductAddDialog: React.FC<{
 };
 
 const ProductGrid: React.FC = () => {
-  const { state, dispatch } = useApp();
+  const { state, dispatch, createProduct } = useApp();
   const [searchTerm, setSearchTerm] = useState('');
   const [showProductDialog, setShowProductDialog] = useState(false);
   const [showProductDropdown, setShowProductDropdown] = useState(false);
@@ -284,8 +284,12 @@ const ProductGrid: React.FC = () => {
     setShowProductDropdown(false);
   };
 
-  const handleSaveProduct = (product: any) => {
-    dispatch({ type: 'ADD_PRODUCT', payload: product });
+  const handleSaveProduct = async (product: any) => {
+    try {
+      await createProduct(product);
+    } catch (error) {
+      console.error('Error adding product:', error);
+    }
   };
 
   const hasNoResults = searchTerm.trim() && filteredProducts.length === 0;

--- a/next_frontend_web/src/components/Layout/Header.tsx
+++ b/next_frontend_web/src/components/Layout/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { ChevronDown, Sun, Moon, LogOut, Menu, MapPin, RefreshCw, Wifi, WifiOff, Database, LucideLanguages } from 'lucide-react';
+import { ChevronDown, Sun, Moon, LogOut, Menu, MapPin, RefreshCw, LucideLanguages } from 'lucide-react';
 import { useApp } from '../../context/MainContext';
 import { useAuth } from '../../context/AuthContext';
 
@@ -53,34 +53,6 @@ const Header: React.FC = () => {
   }
 }, [showLocationDropdown]);
 
-  const getStatusColor = () => {
-    switch (state.syncStatus) {
-      case 'online': return 'text-green-600 dark:text-green-400';
-      case 'offline': return 'text-yellow-600 dark:text-yellow-400';
-      case 'error': return 'text-red-600 dark:text-red-400';
-      default: return 'text-gray-600 dark:text-gray-400';
-    }
-  };
-
-  const getStatusIcon = () => {
-    switch (state.syncStatus) {
-      case 'online': return Wifi;
-      case 'offline': return Database;
-      case 'error': return WifiOff;
-      default: return Database;
-    }
-  };
-
-  const getStatusText = () => {
-    switch (state.syncStatus) {
-      case 'online': return 'Online';
-      case 'offline': return 'Offline';
-      case 'error': return 'Error';
-      default: return 'Loading';
-    }
-  };
-
-  const StatusIcon = getStatusIcon();
   const currentLocation = authState.company?.locations?.find(loc => loc._id === state.currentLocationId);
 
 
@@ -163,29 +135,8 @@ const Header: React.FC = () => {
       </div>
 
       <div className="flex items-center space-x-2">
-        {/* Status Indicators */}
-        <div className="hidden sm:flex items-center space-x-4">
-          <div className={`flex items-center space-x-2 ${getStatusColor()}`}>
-            <StatusIcon className="w-4 h-4" />
-            <span className="text-sm">{getStatusText()}</span>
-          </div>
-          
-          {state.isSyncing && (
-            <div className="flex items-center space-x-2 text-blue-600 dark:text-blue-400">
-              <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse"></div>
-              <span className="text-sm">Syncing</span>
-            </div>
-          )}
-
-          {state.lastSyncTime && (
-            <div className="text-xs text-gray-500 dark:text-gray-400">
-              Last sync: {new Date(state.lastSyncTime).toLocaleTimeString()}
-            </div>
-          )}
-        </div>
-        
         {/* Refresh Button */}
-        <button 
+        <button
           onClick={handleRefresh}
           disabled={isRefreshing}
           className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors disabled:opacity-50"

--- a/next_frontend_web/src/components/MainApp.tsx
+++ b/next_frontend_web/src/components/MainApp.tsx
@@ -56,16 +56,6 @@ const MainApp: React.FC = () => {
             >
               Retry
             </button>
-            <button
-              onClick={() => {
-                if (typeof window !== 'undefined' && (window as any).runDatabaseTests) {
-                  (window as any).runDatabaseTests();
-                }
-              }}
-              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-            >
-              Run DB Tests
-            </button>
           </div>
         </div>
       </div>
@@ -125,39 +115,6 @@ const MainApp: React.FC = () => {
       <MainLayout>
         <div className="h-full flex flex-col">
           {/* Sync Status Banner */}
-          {state.syncStatus === 'offline' && (
-            <div className="bg-yellow-100 dark:bg-yellow-900/30 border-b border-yellow-200 dark:border-yellow-800 px-4 py-2">
-              <div className="flex items-center justify-center space-x-2">
-                <div className="w-2 h-2 bg-yellow-500 rounded-full"></div>
-                <span className="text-yellow-800 dark:text-yellow-300 text-sm">
-                  Working offline - Changes will sync when connection is restored
-                </span>
-              </div>
-            </div>
-          )}
-          
-          {state.syncStatus === 'error' && (
-            <div className="bg-red-100 dark:bg-red-900/30 border-b border-red-200 dark:border-red-800 px-4 py-2">
-              <div className="flex items-center justify-center space-x-2">
-                <div className="w-2 h-2 bg-red-500 rounded-full"></div>
-                <span className="text-red-800 dark:text-red-300 text-sm">
-                  Sync error - Some changes may not be saved
-                </span>
-              </div>
-            </div>
-          )}
-
-          {state.isSyncing && (
-            <div className="bg-blue-100 dark:bg-blue-900/30 border-b border-blue-200 dark:border-blue-800 px-4 py-2">
-              <div className="flex items-center justify-center space-x-2">
-                <div className="w-2 h-2 bg-blue-500 rounded-full animate-pulse"></div>
-                <span className="text-blue-800 dark:text-blue-300 text-sm">
-                  Syncing data...
-                </span>
-              </div>
-            </div>
-          )}
-          
           {/* Main Content */}
           <div className="flex-1 overflow-hidden">
             {renderCurrentView()}

--- a/next_frontend_web/src/components/Misc/ErrorDisplay.tsx
+++ b/next_frontend_web/src/components/Misc/ErrorDisplay.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import { AlertCircle, RefreshCw, Database, Wifi, WifiOff } from 'lucide-react';
-import { useApp } from '../../context/MainContext';
-import { useAuth } from '../../context/AuthContext';
+import { AlertCircle, RefreshCw, Database, WifiOff } from 'lucide-react';
 
 interface ErrorDisplayProps {
   error: string;
@@ -10,8 +8,6 @@ interface ErrorDisplayProps {
 }
 
 const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ error, onRetry, onClearError }) => {
-  const { state } = useApp();
-  const { state: authState } = useAuth();
 
   const getErrorType = (errorMessage: string) => {
     if (errorMessage.includes('Database')) return 'database';
@@ -24,7 +20,7 @@ const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ error, onRetry, onClearErro
   const getErrorIcon = (type: string) => {
     switch (type) {
       case 'database': return Database;
-      case 'network': return state.syncStatus === 'offline' ? WifiOff : Wifi;
+      case 'network': return WifiOff;
       case 'timeout': return RefreshCw;
       default: return AlertCircle;
     }
@@ -59,23 +55,6 @@ const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ error, onRetry, onClearErro
             {error}
           </p>
           
-          {/* Status Information */}
-          <div className="text-xs space-y-1 mb-3">
-            <div className="flex items-center space-x-2">
-              <span className={`text-${colorClass}-600 dark:text-${colorClass}-400`}>Sync Status:</span>
-              <span className={
-                state.syncStatus === 'online' ? 'text-green-600' :
-                state.syncStatus === 'offline' ? 'text-yellow-600' : 'text-red-600'
-              }>
-                {state.syncStatus.charAt(0).toUpperCase() + state.syncStatus.slice(1)}
-              </span>
-            </div>
-            <div className="flex items-center space-x-2">
-              <span className={`text-${colorClass}-600 dark:text-${colorClass}-400`}>Company:</span>
-              <span>{authState.user?.companyId ? 'Connected' : 'Not Connected'}</span>
-            </div>
-          </div>
-
           {/* Action Buttons */}
           <div className="flex space-x-2">
             {onRetry && (

--- a/next_frontend_web/src/services/categories.ts
+++ b/next_frontend_web/src/services/categories.ts
@@ -1,0 +1,7 @@
+import api from './apiClient';
+import { Category } from '../types';
+
+export const getCategories = () => api.get<Category[]>('/categories');
+export const createCategory = (payload: Partial<Category>) => api.post<Category>('/categories', payload);
+export const updateCategory = (id: string, payload: Partial<Category>) => api.put<Category>(`/categories/${id}`, payload);
+export const deleteCategory = (id: string) => api.delete<void>(`/categories/${id}`);

--- a/next_frontend_web/src/services/customers.ts
+++ b/next_frontend_web/src/services/customers.ts
@@ -1,0 +1,13 @@
+import api from './apiClient';
+import { Customer, CreditTransaction } from '../types';
+
+export const getCustomers = () => api.get<Customer[]>('/customers');
+export const createCustomer = (payload: Partial<Customer>) => api.post<Customer>('/customers', payload);
+export const updateCustomer = (id: string, payload: Partial<Customer>) => api.put<Customer>(`/customers/${id}`, payload);
+export const deleteCustomer = (id: string) => api.delete<void>(`/customers/${id}`);
+export const updateCustomerCredit = (id: string, amount: number, type: 'credit' | 'debit', description: string) =>
+  api.post<Customer>(`/customers/${id}/credit`, { amount, type, description });
+export const getCustomerCreditHistory = (id: string) =>
+  api.get<CreditTransaction[]>(`/customers/${id}/credit`);
+export const searchCustomers = (query: string) =>
+  api.get<Customer[]>(`/customers?search=${encodeURIComponent(query)}`);

--- a/next_frontend_web/src/services/dashboard.ts
+++ b/next_frontend_web/src/services/dashboard.ts
@@ -1,0 +1,3 @@
+import api from './apiClient';
+
+export const getStats = () => api.get('/dashboard');

--- a/next_frontend_web/src/services/index.ts
+++ b/next_frontend_web/src/services/index.ts
@@ -1,3 +1,7 @@
 export { default as apiClient } from './apiClient';
 export * as auth from './auth';
 export * as products from './products';
+export * as categories from './categories';
+export * as customers from './customers';
+export * as sales from './sales';
+export * as dashboard from './dashboard';

--- a/next_frontend_web/src/services/products.ts
+++ b/next_frontend_web/src/services/products.ts
@@ -1,9 +1,11 @@
 import api from './apiClient';
 import { Product } from '../types';
 
-export const getProducts = () => api.get<Product[]>('/products');
+export const getProducts = (query = '') =>
+  api.get<Product[]>(`/products${query}`);
 export const getProduct = (id: string) => api.get<Product>(`/products/${id}`);
-export const createProduct = (payload: Partial<Product>) => api.post<Product>('/products', payload);
+export const createProduct = (payload: Partial<Product>) =>
+  api.post<Product>('/products', payload);
 export const updateProduct = (id: string, payload: Partial<Product>) =>
   api.put<Product>(`/products/${id}`, payload);
 export const deleteProduct = (id: string) => api.delete<void>(`/products/${id}`);

--- a/next_frontend_web/src/services/sales.ts
+++ b/next_frontend_web/src/services/sales.ts
@@ -1,0 +1,5 @@
+import api from './apiClient';
+import { Sale } from '../types';
+
+export const getSales = () => api.get<Sale[]>('/sales');
+export const createSale = (payload: Partial<Sale>) => api.post<Sale>('/sales', payload);

--- a/next_frontend_web/src/styles/globals.css
+++ b/next_frontend_web/src/styles/globals.css
@@ -104,18 +104,6 @@
     box-shadow: 0 4px 14px 0 rgba(239, 68, 68, 0.15);
   }
 
-  /* Status indicators */
-  .status-online {
-    @apply flex items-center space-x-2 text-green-600 dark:text-green-400;
-  }
-
-  .status-offline {
-    @apply flex items-center space-x-2 text-red-600 dark:text-red-400;
-  }
-
-  .status-pending {
-    @apply flex items-center space-x-2 text-yellow-600 dark:text-yellow-400;
-  }
 }
 
 /* Utility classes */

--- a/next_frontend_web/src/types/index.ts
+++ b/next_frontend_web/src/types/index.ts
@@ -198,12 +198,7 @@ export interface AppState {
   customers: Customer[];
   suppliers: Supplier[];
   recentSales: Sale[];
-  
-  // Sync State
-  isSyncing: boolean;
-  lastSyncTime: string | null;
-  syncStatus: 'online' | 'offline' | 'error';
-  
+
   // UI Preferences
   theme: 'light' | 'dark';
   sidebarCollapsed: boolean;
@@ -212,14 +207,6 @@ export interface AppState {
   currentPage: number;
   itemsPerPage: number;
   totalItems: number;
-}
-
-// Database Configuration
-export interface DatabaseConfig {
-  localDB: string;
-  remoteDB: string;
-  username?: string;
-  password?: string;
 }
 
 // Dashboard Types
@@ -358,15 +345,6 @@ export interface CategoryFormData {
   name: string;
   description: string;
 }
-
-// Sync Event Types
-export interface SyncEvent {
-  type: 'change' | 'error' | 'complete' | 'online' | 'offline';
-  dbName: string;
-  data: any;
-  timestamp: Date;
-}
-
 // Utility Types
 export type EntityId = string;
 export type Timestamp = string;
@@ -402,7 +380,6 @@ type AppAction =
   | { type: 'SET_CUSTOMER'; payload: Partial<AppState['customer']> }
   | { type: 'SET_RECENT_SALES'; payload: Sale[] }
   | { type: 'ADD_SALE'; payload: Sale }
-  | { type: 'SET_SYNC_STATUS'; payload: { status: 'online' | 'offline' | 'error'; isSyncing: boolean; lastSyncTime?: string } }
   | { type: 'TOGGLE_THEME' }
   | { type: 'SET_THEME'; payload: 'light' | 'dark' }
   | { type: 'TOGGLE_SIDEBAR' }


### PR DESCRIPTION
## Summary
- replace local arrays with category, customer, sales, and dashboard service modules
- initialize app state from HTTP services and expose async CRUD helpers
- drop sync/offline UI and database test hooks

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: interactive ESLint config prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a367e83b34832c8657e0b25e552062