### PR TITLE
feat: support product attribute definitions

### DIFF
--- a/go_backend_rmt/Docs & Schema/PostgrSQL.sql
+++ b/go_backend_rmt/Docs & Schema/PostgrSQL.sql
@@ -964,6 +964,7 @@ CREATE INDEX idx_products_sku ON products(sku);
 CREATE INDEX idx_products_active ON products(company_id, is_active);
 CREATE INDEX idx_product_attributes_company ON product_attributes(company_id);
 CREATE INDEX idx_product_attribute_values_product ON product_attribute_values(product_id);
+CREATE INDEX idx_product_attribute_values_product_attribute ON product_attribute_values(product_id, attribute_id);
 
 -- Categories and Brands
 CREATE INDEX idx_categories_company ON categories(company_id);

--- a/go_backend_rmt/README.md
+++ b/go_backend_rmt/README.md
@@ -12,3 +12,31 @@ Optional query parameters:
 - `phone` – filter by phone number
 - `credit_min` / `credit_max` – credit limit range
 - `balance_min` / `balance_max` – outstanding balance range
+
+## Product Attributes
+
+The API supports dynamic product attributes. First create attribute definitions:
+
+```json
+POST /api/v1/product-attribute-definitions
+{
+  "name": "Color",
+  "type": "SELECT",
+  "is_required": true,
+  "options": "[\"Red\",\"Blue\"]"
+}
+```
+
+Assign values when creating or updating products by providing an `attributes` map where keys are definition IDs:
+
+```json
+POST /api/v1/products
+{
+  "name": "Sample",
+  "barcodes": [{"barcode": "123", "pack_size":1, "cost_price":10, "selling_price":12, "is_primary":true}],
+  "is_serialized": false,
+  "attributes": { "1": "Red" }
+}
+```
+
+Product responses include attribute values with embedded definitions.

--- a/go_backend_rmt/internal/handlers/product_attribute.go
+++ b/go_backend_rmt/internal/handlers/product_attribute.go
@@ -19,29 +19,29 @@ func NewProductAttributeHandler() *ProductAttributeHandler {
 	return &ProductAttributeHandler{service: services.NewProductAttributeService()}
 }
 
-// GET /product-attributes
-func (h *ProductAttributeHandler) GetAttributes(c *gin.Context) {
+// GET /product-attribute-definitions
+func (h *ProductAttributeHandler) GetDefinitions(c *gin.Context) {
 	companyID := c.GetInt("company_id")
 	if companyID == 0 {
 		utils.ForbiddenResponse(c, "Company access required")
 		return
 	}
-	attrs, err := h.service.GetProductAttributes(companyID)
+	defs, err := h.service.GetAttributeDefinitions(companyID)
 	if err != nil {
-		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get product attributes", err)
+		utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to get product attribute definitions", err)
 		return
 	}
-	utils.SuccessResponse(c, "Product attributes retrieved successfully", attrs)
+	utils.SuccessResponse(c, "Product attribute definitions retrieved successfully", defs)
 }
 
-// POST /product-attributes
-func (h *ProductAttributeHandler) CreateAttribute(c *gin.Context) {
+// POST /product-attribute-definitions
+func (h *ProductAttributeHandler) CreateDefinition(c *gin.Context) {
 	companyID := c.GetInt("company_id")
 	if companyID == 0 {
 		utils.ForbiddenResponse(c, "Company access required")
 		return
 	}
-	var req models.CreateProductAttributeRequest
+	var req models.CreateProductAttributeDefinitionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
 		return
@@ -50,16 +50,16 @@ func (h *ProductAttributeHandler) CreateAttribute(c *gin.Context) {
 		utils.ValidationErrorResponse(c, utils.GetValidationErrors(err))
 		return
 	}
-	attr, err := h.service.CreateProductAttribute(companyID, &req)
+	def, err := h.service.CreateAttributeDefinition(companyID, &req)
 	if err != nil {
-		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to create product attribute", err)
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to create product attribute definition", err)
 		return
 	}
-	utils.CreatedResponse(c, "Product attribute created successfully", attr)
+	utils.CreatedResponse(c, "Product attribute definition created successfully", def)
 }
 
-// PUT /product-attributes/:id
-func (h *ProductAttributeHandler) UpdateAttribute(c *gin.Context) {
+// PUT /product-attribute-definitions/:id
+func (h *ProductAttributeHandler) UpdateDefinition(c *gin.Context) {
 	companyID := c.GetInt("company_id")
 	if companyID == 0 {
 		utils.ForbiddenResponse(c, "Company access required")
@@ -70,20 +70,20 @@ func (h *ProductAttributeHandler) UpdateAttribute(c *gin.Context) {
 		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid attribute ID", err)
 		return
 	}
-	var req models.UpdateProductAttributeRequest
+	var req models.UpdateProductAttributeDefinitionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid request body", err)
 		return
 	}
-	if err := h.service.UpdateProductAttribute(id, companyID, &req); err != nil {
-		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update product attribute", err)
+	if err := h.service.UpdateAttributeDefinition(id, companyID, &req); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to update product attribute definition", err)
 		return
 	}
-	utils.SuccessResponse(c, "Product attribute updated successfully", nil)
+	utils.SuccessResponse(c, "Product attribute definition updated successfully", nil)
 }
 
-// DELETE /product-attributes/:id
-func (h *ProductAttributeHandler) DeleteAttribute(c *gin.Context) {
+// DELETE /product-attribute-definitions/:id
+func (h *ProductAttributeHandler) DeleteDefinition(c *gin.Context) {
 	companyID := c.GetInt("company_id")
 	if companyID == 0 {
 		utils.ForbiddenResponse(c, "Company access required")
@@ -94,9 +94,9 @@ func (h *ProductAttributeHandler) DeleteAttribute(c *gin.Context) {
 		utils.ErrorResponse(c, http.StatusBadRequest, "Invalid attribute ID", err)
 		return
 	}
-	if err := h.service.DeleteProductAttribute(id, companyID); err != nil {
-		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to delete product attribute", err)
+	if err := h.service.DeleteAttributeDefinition(id, companyID); err != nil {
+		utils.ErrorResponse(c, http.StatusBadRequest, "Failed to delete product attribute definition", err)
 		return
 	}
-	utils.SuccessResponse(c, "Product attribute deleted successfully", nil)
+	utils.SuccessResponse(c, "Product attribute definition deleted successfully", nil)
 }

--- a/go_backend_rmt/internal/models/product.go
+++ b/go_backend_rmt/internal/models/product.go
@@ -1,25 +1,25 @@
 package models
 
 type Product struct {
-	ProductID    int                `json:"product_id" db:"product_id"`
-	CompanyID    int                `json:"company_id" db:"company_id"`
-	CategoryID   *int               `json:"category_id,omitempty" db:"category_id"`
-	BrandID      *int               `json:"brand_id,omitempty" db:"brand_id"`
-	UnitID       *int               `json:"unit_id,omitempty" db:"unit_id"`
-	Name         string             `json:"name" db:"name" validate:"required,min=2,max=255"`
-	SKU          *string            `json:"sku,omitempty" db:"sku"`
-	Barcodes     []ProductBarcode   `json:"barcodes,omitempty" db:"-"`
-	Description  *string            `json:"description,omitempty" db:"description"`
-	CostPrice    *float64           `json:"cost_price,omitempty" db:"cost_price"`
-	SellingPrice *float64           `json:"selling_price,omitempty" db:"selling_price"`
-	ReorderLevel int                `json:"reorder_level" db:"reorder_level"`
-	Weight       *float64           `json:"weight,omitempty" db:"weight"`
-	Dimensions   *string            `json:"dimensions,omitempty" db:"dimensions"`
-	IsSerialized bool               `json:"is_serialized" db:"is_serialized"`
-	IsActive     bool               `json:"is_active" db:"is_active"`
-	CreatedBy    int                `json:"created_by" db:"created_by"`
-	UpdatedBy    *int               `json:"updated_by,omitempty" db:"updated_by"`
-	Attributes   []ProductAttribute `json:"attributes,omitempty" db:"-"`
+	ProductID    int                     `json:"product_id" db:"product_id"`
+	CompanyID    int                     `json:"company_id" db:"company_id"`
+	CategoryID   *int                    `json:"category_id,omitempty" db:"category_id"`
+	BrandID      *int                    `json:"brand_id,omitempty" db:"brand_id"`
+	UnitID       *int                    `json:"unit_id,omitempty" db:"unit_id"`
+	Name         string                  `json:"name" db:"name" validate:"required,min=2,max=255"`
+	SKU          *string                 `json:"sku,omitempty" db:"sku"`
+	Barcodes     []ProductBarcode        `json:"barcodes,omitempty" db:"-"`
+	Description  *string                 `json:"description,omitempty" db:"description"`
+	CostPrice    *float64                `json:"cost_price,omitempty" db:"cost_price"`
+	SellingPrice *float64                `json:"selling_price,omitempty" db:"selling_price"`
+	ReorderLevel int                     `json:"reorder_level" db:"reorder_level"`
+	Weight       *float64                `json:"weight,omitempty" db:"weight"`
+	Dimensions   *string                 `json:"dimensions,omitempty" db:"dimensions"`
+	IsSerialized bool                    `json:"is_serialized" db:"is_serialized"`
+	IsActive     bool                    `json:"is_active" db:"is_active"`
+	CreatedBy    int                     `json:"created_by" db:"created_by"`
+	UpdatedBy    *int                    `json:"updated_by,omitempty" db:"updated_by"`
+	Attributes   []ProductAttributeValue `json:"attributes,omitempty" db:"-"`
 	SyncModel
 }
 
@@ -37,6 +37,7 @@ type CreateProductRequest struct {
 	Weight       *float64         `json:"weight,omitempty"`
 	Dimensions   *string          `json:"dimensions,omitempty"`
 	IsSerialized bool             `json:"is_serialized"`
+	Attributes   map[int]string   `json:"attributes,omitempty"`
 }
 
 type UpdateProductRequest struct {
@@ -54,6 +55,7 @@ type UpdateProductRequest struct {
 	Dimensions   *string          `json:"dimensions,omitempty"`
 	IsSerialized *bool            `json:"is_serialized,omitempty"`
 	IsActive     *bool            `json:"is_active,omitempty"`
+	Attributes   map[int]string   `json:"attributes,omitempty"`
 }
 
 type Category struct {

--- a/go_backend_rmt/internal/models/product_attribute.go
+++ b/go_backend_rmt/internal/models/product_attribute.go
@@ -1,23 +1,42 @@
 package models
 
-// ProductAttribute represents a custom attribute for products
-// Example: color, size, material etc.
-type ProductAttribute struct {
-	AttributeID int    `json:"attribute_id" db:"attribute_id"`
-	CompanyID   int    `json:"company_id" db:"company_id"`
-	Name        string `json:"name" db:"name" validate:"required"`
-	Value       string `json:"value" db:"value" validate:"required"`
+// ProductAttributeDefinition represents a definable attribute for products
+// e.g. color, size with metadata like type and requirement
+// Options is JSON for SELECT type
+// Example: {"Red","Blue"}
+type ProductAttributeDefinition struct {
+	AttributeID int     `json:"attribute_id" db:"attribute_id"`
+	CompanyID   int     `json:"company_id" db:"company_id"`
+	Name        string  `json:"name" db:"name" validate:"required"`
+	Type        string  `json:"type" db:"type" validate:"required,oneof=TEXT NUMBER DATE BOOLEAN SELECT"`
+	IsRequired  bool    `json:"is_required" db:"is_required"`
+	Options     *string `json:"options,omitempty" db:"options"`
 	BaseModel
 	SyncModel
 }
 
-type CreateProductAttributeRequest struct {
-	Name  string `json:"name" validate:"required"`
-	Value string `json:"value" validate:"required"`
+// ProductAttributeValue stores value of attribute for a product
+// Definition holds the attribute definition metadata
+// Value is stored as string; service ensures type correctness
+type ProductAttributeValue struct {
+	AttributeID int                        `json:"attribute_id" db:"attribute_id"`
+	ProductID   int                        `json:"product_id" db:"product_id"`
+	Value       string                     `json:"value" db:"value"`
+	Definition  ProductAttributeDefinition `json:"definition" db:"-"`
 }
 
-type UpdateProductAttributeRequest struct {
-	Name     *string `json:"name,omitempty"`
-	Value    *string `json:"value,omitempty"`
-	IsActive *bool   `json:"is_active,omitempty"`
+// Requests for attribute definition management
+type CreateProductAttributeDefinitionRequest struct {
+	Name       string  `json:"name" validate:"required"`
+	Type       string  `json:"type" validate:"required,oneof=TEXT NUMBER DATE BOOLEAN SELECT"`
+	IsRequired bool    `json:"is_required"`
+	Options    *string `json:"options,omitempty"`
+}
+
+type UpdateProductAttributeDefinitionRequest struct {
+	Name       *string `json:"name,omitempty"`
+	Type       *string `json:"type,omitempty"`
+	IsRequired *bool   `json:"is_required,omitempty"`
+	Options    *string `json:"options,omitempty"`
+	IsActive   *bool   `json:"is_active,omitempty"`
 }

--- a/go_backend_rmt/internal/routes/routes.go
+++ b/go_backend_rmt/internal/routes/routes.go
@@ -201,14 +201,14 @@ func Initialize(router *gin.Engine, cfg *config.Config) {
 				units.POST("", middleware.RequireRole("Admin"), productHandler.CreateUnit)
 			}
 
-			// Product attribute management routes
-			attributes := protected.Group("/product-attributes")
-			attributes.Use(middleware.RequireCompanyAccess())
+			// Product attribute definition management routes
+			attrDefs := protected.Group("/product-attribute-definitions")
+			attrDefs.Use(middleware.RequireCompanyAccess())
 			{
-				attributes.GET("", middleware.RequirePermission("VIEW_PRODUCTS"), productAttributeHandler.GetAttributes)
-				attributes.POST("", middleware.RequirePermission("CREATE_PRODUCTS"), productAttributeHandler.CreateAttribute)
-				attributes.PUT("/:id", middleware.RequirePermission("UPDATE_PRODUCTS"), productAttributeHandler.UpdateAttribute)
-				attributes.DELETE("/:id", middleware.RequirePermission("DELETE_PRODUCTS"), productAttributeHandler.DeleteAttribute)
+				attrDefs.GET("", middleware.RequirePermission("VIEW_PRODUCTS"), productAttributeHandler.GetDefinitions)
+				attrDefs.POST("", middleware.RequirePermission("CREATE_PRODUCTS"), productAttributeHandler.CreateDefinition)
+				attrDefs.PUT("/:id", middleware.RequirePermission("UPDATE_PRODUCTS"), productAttributeHandler.UpdateDefinition)
+				attrDefs.DELETE("/:id", middleware.RequirePermission("DELETE_PRODUCTS"), productAttributeHandler.DeleteDefinition)
 			}
 
 			// ADD THESE NEW INVENTORY ROUTES:

--- a/go_backend_rmt/internal/services/product_attribute_service.go
+++ b/go_backend_rmt/internal/services/product_attribute_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"erp-backend/internal/database"
 	"erp-backend/internal/models"
@@ -16,44 +17,47 @@ func NewProductAttributeService() *ProductAttributeService {
 	return &ProductAttributeService{db: database.GetDB()}
 }
 
-// GetProductAttributes returns all attributes for a company
-func (s *ProductAttributeService) GetProductAttributes(companyID int) ([]models.ProductAttribute, error) {
+// GetAttributeDefinitions returns all attribute definitions for a company
+func (s *ProductAttributeService) GetAttributeDefinitions(companyID int) ([]models.ProductAttributeDefinition, error) {
 	rows, err := s.db.Query(`
-        SELECT attribute_id, company_id, name, value, sync_status, created_at, updated_at, is_deleted
+        SELECT attribute_id, company_id, name, type, is_required, options, sync_status, created_at, updated_at, is_deleted
         FROM product_attributes WHERE company_id = $1 AND is_deleted = FALSE`, companyID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get product attributes: %w", err)
+		return nil, fmt.Errorf("failed to get product attribute definitions: %w", err)
 	}
 	defer rows.Close()
 
-	var attrs []models.ProductAttribute
+	var defs []models.ProductAttributeDefinition
 	for rows.Next() {
-		var a models.ProductAttribute
-		if err := rows.Scan(&a.AttributeID, &a.CompanyID, &a.Name, &a.Value, &a.SyncStatus, &a.CreatedAt, &a.UpdatedAt, &a.IsDeleted); err != nil {
-			return nil, fmt.Errorf("failed to scan attribute: %w", err)
+		var d models.ProductAttributeDefinition
+		if err := rows.Scan(&d.AttributeID, &d.CompanyID, &d.Name, &d.Type, &d.IsRequired, &d.Options, &d.SyncStatus, &d.CreatedAt, &d.UpdatedAt, &d.IsDeleted); err != nil {
+			return nil, fmt.Errorf("failed to scan attribute definition: %w", err)
 		}
-		attrs = append(attrs, a)
+		defs = append(defs, d)
 	}
-	return attrs, nil
+	return defs, nil
 }
 
-// CreateProductAttribute adds a new attribute
-func (s *ProductAttributeService) CreateProductAttribute(companyID int, req *models.CreateProductAttributeRequest) (*models.ProductAttribute, error) {
-	var attr models.ProductAttribute
+// CreateAttributeDefinition adds a new attribute definition
+func (s *ProductAttributeService) CreateAttributeDefinition(companyID int, req *models.CreateProductAttributeDefinitionRequest) (*models.ProductAttributeDefinition, error) {
+	var def models.ProductAttributeDefinition
 	err := s.db.QueryRow(`
-        INSERT INTO product_attributes (company_id, name, value) VALUES ($1,$2,$3)
-        RETURNING attribute_id, created_at`, companyID, req.Name, req.Value).Scan(&attr.AttributeID, &attr.CreatedAt)
+        INSERT INTO product_attributes (company_id, name, type, is_required, options)
+        VALUES ($1,$2,$3,$4,$5)
+        RETURNING attribute_id, created_at`, companyID, req.Name, req.Type, req.IsRequired, req.Options).Scan(&def.AttributeID, &def.CreatedAt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create attribute: %w", err)
+		return nil, fmt.Errorf("failed to create attribute definition: %w", err)
 	}
-	attr.CompanyID = companyID
-	attr.Name = req.Name
-	attr.Value = req.Value
-	return &attr, nil
+	def.CompanyID = companyID
+	def.Name = req.Name
+	def.Type = req.Type
+	def.IsRequired = req.IsRequired
+	def.Options = req.Options
+	return &def, nil
 }
 
-// UpdateProductAttribute updates an existing attribute
-func (s *ProductAttributeService) UpdateProductAttribute(id, companyID int, req *models.UpdateProductAttributeRequest) error {
+// UpdateAttributeDefinition updates an existing attribute definition
+func (s *ProductAttributeService) UpdateAttributeDefinition(id, companyID int, req *models.UpdateProductAttributeDefinitionRequest) error {
 	query := "UPDATE product_attributes SET "
 	params := []interface{}{}
 	idx := 1
@@ -63,9 +67,19 @@ func (s *ProductAttributeService) UpdateProductAttribute(id, companyID int, req 
 		params = append(params, *req.Name)
 		idx++
 	}
-	if req.Value != nil {
-		query += fmt.Sprintf("value = $%d,", idx)
-		params = append(params, *req.Value)
+	if req.Type != nil {
+		query += fmt.Sprintf("type = $%d,", idx)
+		params = append(params, *req.Type)
+		idx++
+	}
+	if req.IsRequired != nil {
+		query += fmt.Sprintf("is_required = $%d,", idx)
+		params = append(params, *req.IsRequired)
+		idx++
+	}
+	if req.Options != nil {
+		query += fmt.Sprintf("options = $%d,", idx)
+		params = append(params, *req.Options)
 		idx++
 	}
 	if req.IsActive != nil {
@@ -80,18 +94,45 @@ func (s *ProductAttributeService) UpdateProductAttribute(id, companyID int, req 
 	query += fmt.Sprintf(" WHERE attribute_id = $%d AND company_id = $%d", idx, idx+1)
 	params = append(params, id, companyID)
 
-	_, err := s.db.Exec(query, params...)
-	if err != nil {
-		return fmt.Errorf("failed to update attribute: %w", err)
+	if _, err := s.db.Exec(query, params...); err != nil {
+		return fmt.Errorf("failed to update attribute definition: %w", err)
 	}
 	return nil
 }
 
-// DeleteProductAttribute soft deletes an attribute
-func (s *ProductAttributeService) DeleteProductAttribute(id, companyID int) error {
+// DeleteAttributeDefinition soft deletes an attribute definition
+func (s *ProductAttributeService) DeleteAttributeDefinition(id, companyID int) error {
 	_, err := s.db.Exec(`UPDATE product_attributes SET is_deleted = TRUE WHERE attribute_id = $1 AND company_id = $2`, id, companyID)
 	if err != nil {
-		return fmt.Errorf("failed to delete attribute: %w", err)
+		return fmt.Errorf("failed to delete attribute definition: %w", err)
 	}
 	return nil
+}
+
+// GetDefinitionsByIDs returns definitions for given IDs
+func (s *ProductAttributeService) GetDefinitionsByIDs(companyID int, ids []int) (map[int]models.ProductAttributeDefinition, error) {
+	if len(ids) == 0 {
+		return map[int]models.ProductAttributeDefinition{}, nil
+	}
+	placeholders := make([]string, len(ids))
+	args := []interface{}{companyID}
+	for i, id := range ids {
+		placeholders[i] = fmt.Sprintf("$%d", i+2)
+		args = append(args, id)
+	}
+	query := fmt.Sprintf(`SELECT attribute_id, company_id, name, type, is_required, options FROM product_attributes WHERE company_id = $1 AND attribute_id IN (%s) AND is_deleted = FALSE`, strings.Join(placeholders, ","))
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make(map[int]models.ProductAttributeDefinition)
+	for rows.Next() {
+		var d models.ProductAttributeDefinition
+		if err := rows.Scan(&d.AttributeID, &d.CompanyID, &d.Name, &d.Type, &d.IsRequired, &d.Options); err != nil {
+			return nil, err
+		}
+		result[d.AttributeID] = d
+	}
+	return result, nil
 }

--- a/go_backend_rmt/internal/services/product_attribute_service_test.go
+++ b/go_backend_rmt/internal/services/product_attribute_service_test.go
@@ -1,0 +1,70 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"erp-backend/internal/models"
+)
+
+var attrLastQuery string
+var attrLastArgs []driver.NamedValue
+
+type attrMockDriver struct{}
+
+func (d *attrMockDriver) Open(name string) (driver.Conn, error) { return &attrMockConn{}, nil }
+
+type attrMockConn struct{}
+
+func (c *attrMockConn) Prepare(query string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+func (c *attrMockConn) Close() error              { return nil }
+func (c *attrMockConn) Begin() (driver.Tx, error) { return nil, errors.New("not implemented") }
+func (c *attrMockConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	attrLastQuery = query
+	attrLastArgs = append([]driver.NamedValue(nil), args...)
+	return &attrMockRows{}, nil
+}
+
+type attrMockRows struct{ returned bool }
+
+func (r *attrMockRows) Columns() []string { return []string{"attribute_id", "created_at"} }
+func (r *attrMockRows) Close() error      { return nil }
+func (r *attrMockRows) Next(dest []driver.Value) error {
+	if r.returned {
+		return io.EOF
+	}
+	dest[0] = int64(1)
+	dest[1] = time.Now()
+	r.returned = true
+	return nil
+}
+
+func TestCreateAttributeDefinition_IncludesFields(t *testing.T) {
+	sql.Register("attrMock", &attrMockDriver{})
+	db, err := sql.Open("attrMock", "")
+	if err != nil {
+		t.Fatalf("open mock: %v", err)
+	}
+	svc := &ProductAttributeService{db: db}
+	req := &models.CreateProductAttributeDefinitionRequest{Name: "Color", Type: "TEXT", IsRequired: true}
+	attrLastQuery = ""
+	attrLastArgs = nil
+	_, err = svc.CreateAttributeDefinition(1, req)
+	if err != nil {
+		t.Fatalf("CreateAttributeDefinition error: %v", err)
+	}
+	if !strings.Contains(attrLastQuery, "name, type, is_required, options") {
+		t.Fatalf("unexpected query: %s", attrLastQuery)
+	}
+	if len(attrLastArgs) < 5 {
+		t.Fatalf("expected 5 args, got %d", len(attrLastArgs))
+	}
+}

--- a/go_backend_rmt/internal/services/product_service_attributes_test.go
+++ b/go_backend_rmt/internal/services/product_service_attributes_test.go
@@ -1,0 +1,49 @@
+package services
+
+import (
+	"database/sql"
+	"testing"
+
+	"erp-backend/internal/models"
+)
+
+type mockExec struct{ queries []string }
+
+func (m *mockExec) Exec(query string, args ...interface{}) (sql.Result, error) {
+	m.queries = append(m.queries, query)
+	return paMockResult{}, nil
+}
+
+type paMockResult struct{}
+
+func (paMockResult) LastInsertId() (int64, error) { return 0, nil }
+func (paMockResult) RowsAffected() (int64, error) { return 0, nil }
+
+type mockAttrProvider struct {
+	defs []models.ProductAttributeDefinition
+}
+
+func (m *mockAttrProvider) GetAttributeDefinitions(companyID int) ([]models.ProductAttributeDefinition, error) {
+	return m.defs, nil
+}
+
+func TestValidateAndSaveAttributes_Success(t *testing.T) {
+	svc := &ProductService{attributeService: &mockAttrProvider{defs: []models.ProductAttributeDefinition{{AttributeID: 1, Name: "Color", Type: "TEXT", IsRequired: true}}}}
+	exec := &mockExec{}
+	attrs := map[int]string{1: "Red"}
+	if err := svc.validateAndSaveAttributes(exec, 1, 1, attrs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(exec.queries) < 2 { // delete + insert
+		t.Fatalf("expected queries to be executed, got %v", exec.queries)
+	}
+}
+
+func TestValidateAndSaveAttributes_MissingRequired(t *testing.T) {
+	svc := &ProductService{attributeService: &mockAttrProvider{defs: []models.ProductAttributeDefinition{{AttributeID: 1, Name: "Color", Type: "TEXT", IsRequired: true}}}}
+	exec := &mockExec{}
+	err := svc.validateAndSaveAttributes(exec, 1, 1, map[int]string{})
+	if err == nil {
+		t.Fatalf("expected error for missing required attribute")
+	}
+}

--- a/go_backend_rmt/migrations/008_product_attributes.sql
+++ b/go_backend_rmt/migrations/008_product_attributes.sql
@@ -1,0 +1,22 @@
+-- Migration to align product attributes schema and add index
+-- Adds type, is_required, options to product_attributes and creates
+-- product_attribute_values table with composite index on (product_id, attribute_id)
+
+-- Update product_attributes table
+ALTER TABLE IF EXISTS product_attributes
+    ADD COLUMN IF NOT EXISTS type VARCHAR(50) NOT NULL DEFAULT 'TEXT',
+    ADD COLUMN IF NOT EXISTS is_required BOOLEAN DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS options JSONB,
+    DROP COLUMN IF EXISTS value;
+
+-- Create product_attribute_values table if it does not exist
+CREATE TABLE IF NOT EXISTS product_attribute_values (
+    value_id SERIAL PRIMARY KEY,
+    product_id INTEGER NOT NULL REFERENCES products(product_id) ON DELETE CASCADE,
+    attribute_id INTEGER NOT NULL REFERENCES product_attributes(attribute_id),
+    value TEXT NOT NULL
+);
+
+-- Add composite index for fast lookups
+CREATE INDEX IF NOT EXISTS idx_product_attribute_values_product_attribute
+    ON product_attribute_values(product_id, attribute_id);


### PR DESCRIPTION
## Summary
- separate product attribute definitions from values
- persist and validate product attribute values on products
- document and test product attribute workflows

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a4979660ac832ca27db2a7f6014cfa