### PR TITLE
Enforce single primary product barcode

### DIFF
--- a/go_backend_rmt/internal/services/product_service_barcode_test.go
+++ b/go_backend_rmt/internal/services/product_service_barcode_test.go
@@ -1,0 +1,44 @@
+package services
+
+import (
+	"testing"
+
+	"erp-backend/internal/models"
+)
+
+func TestCreateProduct_InvalidPrimaryBarcode(t *testing.T) {
+	svc := &ProductService{}
+	req := &models.CreateProductRequest{
+		Name: "Test",
+		Barcodes: []models.ProductBarcode{
+			{Barcode: "111"},
+			{Barcode: "222"},
+		},
+	}
+	if _, err := svc.CreateProduct(1, 1, req); err == nil {
+		t.Fatalf("expected error for missing primary barcode")
+	}
+	req.Barcodes[0].IsPrimary = true
+	req.Barcodes[1].IsPrimary = true
+	if _, err := svc.CreateProduct(1, 1, req); err == nil {
+		t.Fatalf("expected error for multiple primary barcodes")
+	}
+}
+
+func TestUpdateProduct_InvalidPrimaryBarcode(t *testing.T) {
+	svc := &ProductService{}
+	req := &models.UpdateProductRequest{
+		Barcodes: []models.ProductBarcode{
+			{Barcode: "111"},
+			{Barcode: "222"},
+		},
+	}
+	if err := svc.UpdateProduct(1, 1, 1, req); err == nil {
+		t.Fatalf("expected error for missing primary barcode")
+	}
+	req.Barcodes[0].IsPrimary = true
+	req.Barcodes[1].IsPrimary = true
+	if err := svc.UpdateProduct(1, 1, 1, req); err == nil {
+		t.Fatalf("expected error for multiple primary barcodes")
+	}
+}

--- a/go_backend_rmt/migrations/009_add_primary_barcode_unique_index.sql
+++ b/go_backend_rmt/migrations/009_add_primary_barcode_unique_index.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX ux_product_barcodes_primary ON product_barcodes(product_id) WHERE is_primary;


### PR DESCRIPTION
## Summary
- add partial unique index ensuring only one primary barcode per product
- validate CreateProduct and UpdateProduct to require exactly one primary barcode
- test service methods for primary barcode validation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a49d85d904832cb2b767a92b2be6da