### PR TITLE
feat: enhance header with sync and language controls

### DIFF
--- a/next_frontend_web/src/context/MainContext.tsx
+++ b/next_frontend_web/src/context/MainContext.tsx
@@ -18,6 +18,9 @@ const initialState: AppState = {
   recentSales: [],
   theme: 'light',
   sidebarCollapsed: false,
+  language: 'en',
+  lastSync: null,
+  isSyncing: false,
   currentPage: 1,
   itemsPerPage: 20,
   totalItems: 0,
@@ -100,6 +103,12 @@ const appReducer = (state: AppState, action: AppAction): AppState => {
       return { ...state, sidebarCollapsed: !state.sidebarCollapsed };
     case 'SET_PAGINATION':
       return { ...state, currentPage: action.payload.currentPage, totalItems: action.payload.totalItems };
+    case 'SET_LANGUAGE':
+      return { ...state, language: action.payload };
+    case 'SET_LAST_SYNC':
+      return { ...state, lastSync: action.payload };
+    case 'SET_SYNCING':
+      return { ...state, isSyncing: action.payload };
     case 'RESET_STATE':
       return { ...initialState };
     default:
@@ -150,13 +159,16 @@ export const MainProvider = ({ children }: { children: ReactNode }) => {
 
   const loadAllData = async () => {
     dispatch({ type: 'SET_LOADING', payload: true });
+    dispatch({ type: 'SET_SYNCING', payload: true });
     try {
       await Promise.all([loadProducts(), loadCategories(), loadCustomers(), loadSales()]);
       dispatch({ type: 'SET_INITIALIZED', payload: true });
+      dispatch({ type: 'SET_LAST_SYNC', payload: new Date().toISOString() });
     } catch (error: any) {
       dispatch({ type: 'SET_ERROR', payload: error.message });
     } finally {
       dispatch({ type: 'SET_LOADING', payload: false });
+      dispatch({ type: 'SET_SYNCING', payload: false });
     }
   };
 
@@ -320,6 +332,10 @@ export const MainProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
+  const setLanguage = (lang: string) => {
+    dispatch({ type: 'SET_LANGUAGE', payload: lang });
+  };
+
   useEffect(() => {
     loadAllData();
   }, []);
@@ -350,6 +366,7 @@ export const MainProvider = ({ children }: { children: ReactNode }) => {
         createSale,
         setCurrentLocation,
         getDashboardStats,
+        setLanguage,
       }}
     >
       {children}

--- a/next_frontend_web/src/types/index.ts
+++ b/next_frontend_web/src/types/index.ts
@@ -217,7 +217,12 @@ export interface AppState {
   // UI Preferences
   theme: 'light' | 'dark';
   sidebarCollapsed: boolean;
-  
+  language: string;
+
+  // Sync Status
+  lastSync: string | null;
+  isSyncing: boolean;
+
   // Pagination
   currentPage: number;
   itemsPerPage: number;
@@ -409,6 +414,9 @@ type AppAction =
   | { type: 'SET_THEME'; payload: 'light' | 'dark' }
   | { type: 'TOGGLE_SIDEBAR' }
   | { type: 'SET_PAGINATION'; payload: { currentPage: number; totalItems: number } }
+  | { type: 'SET_LANGUAGE'; payload: string }
+  | { type: 'SET_LAST_SYNC'; payload: string | null }
+  | { type: 'SET_SYNCING'; payload: boolean }
   | { type: 'RESET_STATE' };
 
 type AuthAction =


### PR DESCRIPTION
## Summary
- add online/offline indicator and sync status display
- include help menu and dual-language dropdown in header
- track sync timestamps in context and expose language setter

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden for @typescript-eslint/eslint-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b02d5e1c832c8662549903090f58