### PR TITLE
Add company and location context handling

### DIFF
--- a/next_frontend_web/src/context/MainContext.tsx
+++ b/next_frontend_web/src/context/MainContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useReducer, ReactNode, useEffect } fr
 import { AppState, AppAction, Product, Category, Customer, Sale } from '../types';
 import { products, categories, customers, sales, dashboard } from '../services';
 import { useAuth } from './AuthContext';
+import { setCompanyLocation } from '../services/apiClient';
 
 const initialState: AppState = {
   currentView: 'dashboard',
@@ -9,6 +10,7 @@ const initialState: AppState = {
   isLoading: false,
   isInitialized: false,
   error: null,
+  currentCompanyId: null,
   currentLocationId: null,
   cart: [],
   customer: { phone: '', name: '', creditBalance: 0, address: '' },
@@ -29,6 +31,8 @@ const initialState: AppState = {
 
 const appReducer = (state: AppState, action: AppAction): AppState => {
   switch (action.type) {
+    case 'SET_CURRENT_COMPANY':
+      return { ...state, currentCompanyId: action.payload };
     case 'SET_CURRENT_LOCATION':
       return { ...state, currentLocationId: action.payload };
     case 'SET_LOADING':
@@ -149,6 +153,10 @@ export const MainProvider = ({ children }: { children: ReactNode }) => {
       }
     }
   }, [state.theme, state.language]);
+
+  useEffect(() => {
+    setCompanyLocation(state.currentCompanyId, state.currentLocationId);
+  }, [state.currentCompanyId, state.currentLocationId]);
 
   const loadProducts = async () => {
     try {
@@ -347,8 +355,15 @@ export const MainProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
+  const setCurrentCompany = async (companyId: string) => {
+    dispatch({ type: 'SET_CURRENT_COMPANY', payload: companyId });
+    setCompanyLocation(companyId, state.currentLocationId);
+    await loadAllData();
+  };
+
   const setCurrentLocation = async (locationId: string) => {
     dispatch({ type: 'SET_CURRENT_LOCATION', payload: locationId });
+    setCompanyLocation(state.currentCompanyId, locationId);
     await loadAllData();
   };
 
@@ -394,6 +409,7 @@ export const MainProvider = ({ children }: { children: ReactNode }) => {
         searchCustomers,
         getProductsByCategory,
         createSale,
+        setCurrentCompany,
         setCurrentLocation,
         getDashboardStats,
         setLanguage,
@@ -434,6 +450,7 @@ export const useAppActions = () => {
     searchCustomers,
     getProductsByCategory,
     createSale,
+    setCurrentCompany,
     setCurrentLocation,
     getDashboardStats,
   } = useContext(MainContext);
@@ -458,6 +475,7 @@ export const useAppActions = () => {
     searchCustomers,
     getProductsByCategory,
     createSale,
+    setCurrentCompany,
     setCurrentLocation,
     getDashboardStats,
   };

--- a/next_frontend_web/src/services/apiClient.ts
+++ b/next_frontend_web/src/services/apiClient.ts
@@ -2,6 +2,8 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || '';
 
 let accessToken: string | null = null;
 let refreshToken: string | null = null;
+let companyId: string | null = null;
+let locationId: string | null = null;
 
 if (typeof window !== 'undefined') {
   accessToken = localStorage.getItem('accessToken');
@@ -30,6 +32,14 @@ export const clearAuthTokens = () => {
     localStorage.removeItem('accessToken');
     localStorage.removeItem('refreshToken');
   }
+};
+
+export const setCompanyLocation = (
+  company: string | null,
+  location: string | null
+) => {
+  companyId = company;
+  locationId = location;
 };
 
 const toSnakeCase = (obj: any): any => {
@@ -81,6 +91,12 @@ async function request<T>(endpoint: string, options: RequestOptions = {}): Promi
 
   if (auth && accessToken) {
     (config.headers as Record<string, string>)['Authorization'] = `Bearer ${accessToken}`;
+  }
+  if (companyId) {
+    (config.headers as Record<string, string>)['company_id'] = companyId;
+  }
+  if (locationId) {
+    (config.headers as Record<string, string>)['location_id'] = locationId;
   }
 
   let response = await fetch(`${API_BASE_URL}${endpoint}`, config);

--- a/next_frontend_web/src/types/index.ts
+++ b/next_frontend_web/src/types/index.ts
@@ -196,6 +196,7 @@ export interface AppState {
   isLoading: boolean;
   isInitialized: boolean;
   error: string | null;
+  currentCompanyId: string | null;
   currentLocationId: string | null;
   
   // Cart State
@@ -384,6 +385,7 @@ export type Currency = number;
 
 // Action Types for Reducers
 type AppAction =
+  | { type: 'SET_CURRENT_COMPANY'; payload: string }
   | { type: 'SET_CURRENT_LOCATION'; payload: string }
   | { type: 'LOAD_ALL_DATA' }
   | { type: 'SET_LOADING'; payload: boolean }


### PR DESCRIPTION
## Summary
- Track `currentCompanyId` and `currentLocationId` in MainContext
- Include company and location headers on all API requests
- Extend types to support new identifiers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b7fab98c832c9aa457002d1c0fb4