### PR TITLE
Add POS pages and interfaces

### DIFF
--- a/next_frontend_web/src/components/ERP/Sales/ClassicPOS.tsx
+++ b/next_frontend_web/src/components/ERP/Sales/ClassicPOS.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import POSBase from './POSBase';
+
+const ClassicPOS: React.FC = () => <POSBase variant="classic" />;
+
+export default ClassicPOS;

--- a/next_frontend_web/src/components/ERP/Sales/InvoiceView.tsx
+++ b/next_frontend_web/src/components/ERP/Sales/InvoiceView.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { useAppState } from '../../../context/MainContext';
+
+const InvoiceView: React.FC = () => {
+  const state = useAppState(s => s);
+  const total = state.cart.reduce(
+    (sum, item) => sum + item.product.price * item.quantity,
+    0
+  );
+
+  const shareInvoice = (method: 'print' | 'whatsapp' | 'sms' | 'email') => {
+    const message = `Invoice Total: ${total.toFixed(2)}`;
+    switch (method) {
+      case 'print':
+        window.print();
+        break;
+      case 'whatsapp':
+        window.open(`https://wa.me/?text=${encodeURIComponent(message)}`);
+        break;
+      case 'sms':
+        window.open(`sms:?body=${encodeURIComponent(message)}`);
+        break;
+      case 'email':
+        window.location.href = `mailto:?subject=Invoice&body=${encodeURIComponent(message)}`;
+        break;
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-semibold">Invoice</h2>
+      <ul className="border p-2 divide-y">
+        {state.cart.map(item => (
+          <li key={item.product._id} className="py-1 flex justify-between">
+            <span>
+              {item.product.name} x{item.quantity}
+            </span>
+            <span>{(item.product.price * item.quantity).toFixed(2)}</span>
+          </li>
+        ))}
+      </ul>
+      <div className="font-bold">Total: {total.toFixed(2)}</div>
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={() => shareInvoice('print')}
+          className="px-3 py-2 bg-gray-200 rounded"
+        >
+          Print
+        </button>
+        <button
+          onClick={() => shareInvoice('whatsapp')}
+          className="px-3 py-2 bg-green-500 text-white rounded"
+        >
+          WhatsApp
+        </button>
+        <button
+          onClick={() => shareInvoice('sms')}
+          className="px-3 py-2 bg-blue-500 text-white rounded"
+        >
+          SMS
+        </button>
+        <button
+          onClick={() => shareInvoice('email')}
+          className="px-3 py-2 bg-indigo-500 text-white rounded"
+        >
+          Email
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default InvoiceView;

--- a/next_frontend_web/src/components/ERP/Sales/ModernPOS.tsx
+++ b/next_frontend_web/src/components/ERP/Sales/ModernPOS.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import POSBase from './POSBase';
+
+interface ModernPOSProps {
+  mode?: 'sale' | 'return';
+}
+
+const ModernPOS: React.FC<ModernPOSProps> = ({ mode }) => (
+  <POSBase variant="modern" mode={mode} />
+);
+
+export default ModernPOS;

--- a/next_frontend_web/src/components/ERP/Sales/POSBase.tsx
+++ b/next_frontend_web/src/components/ERP/Sales/POSBase.tsx
@@ -1,0 +1,147 @@
+import React, { useState } from 'react';
+import { useAppState, useAppDispatch, useAppActions } from '../../../context/MainContext';
+import { Product } from '../../../types';
+
+interface POSBaseProps {
+  variant: 'classic' | 'modern';
+  mode?: 'sale' | 'return';
+}
+
+const POSBase: React.FC<POSBaseProps> = ({ variant, mode = 'sale' }) => {
+  const state = useAppState(s => s);
+  const dispatch = useAppDispatch();
+  const { searchProducts } = useAppActions();
+
+  const [barcode, setBarcode] = useState('');
+  const [discount, setDiscount] = useState(0);
+  const [tax, setTax] = useState(0);
+  const [loyalty, setLoyalty] = useState(0);
+  const [promo, setPromo] = useState('');
+
+  const handleBarcodeKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && barcode.trim()) {
+      const results = searchProducts(barcode.trim());
+      if (results.length > 0) {
+        dispatch({ type: 'ADD_TO_CART', payload: results[0] as Product });
+      }
+      setBarcode('');
+    }
+  };
+
+  const subtotal = state.cart.reduce(
+    (sum, item) => sum + item.product.price * item.quantity,
+    0
+  );
+  const discountAmount = subtotal * (discount / 100);
+  const promoAmount = promo === 'PROMO10' ? subtotal * 0.1 : 0;
+  const loyaltyAmount = loyalty;
+  const taxedBase = subtotal - discountAmount - promoAmount - loyaltyAmount;
+  const taxAmount = taxedBase * (tax / 100);
+  const total = mode === 'return' ? -(taxedBase + taxAmount) : taxedBase + taxAmount;
+
+  const shareInvoice = (method: 'print' | 'whatsapp' | 'sms' | 'email') => {
+    const message = `Invoice Total: ${total.toFixed(2)}`;
+    switch (method) {
+      case 'print':
+        window.print();
+        break;
+      case 'whatsapp':
+        window.open(`https://wa.me/?text=${encodeURIComponent(message)}`);
+        break;
+      case 'sms':
+        window.open(`sms:?body=${encodeURIComponent(message)}`);
+        break;
+      case 'email':
+        window.location.href = `mailto:?subject=Invoice&body=${encodeURIComponent(message)}`;
+        break;
+    }
+  };
+
+  return (
+    <div
+      className={
+        variant === 'modern'
+          ? 'p-4 space-y-4 bg-gray-50 dark:bg-gray-900 rounded-lg'
+          : 'space-y-4'
+      }
+    >
+      <div>
+        <input
+          value={barcode}
+          onChange={e => setBarcode(e.target.value)}
+          onKeyDown={handleBarcodeKey}
+          placeholder="Scan barcode"
+          className="border p-2 w-full"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <input
+          type="number"
+          value={discount}
+          onChange={e => setDiscount(parseFloat(e.target.value) || 0)}
+          placeholder="Discount %"
+          className="border p-2 w-full"
+        />
+        <input
+          type="number"
+          value={tax}
+          onChange={e => setTax(parseFloat(e.target.value) || 0)}
+          placeholder="Tax %"
+          className="border p-2 w-full"
+        />
+        <input
+          type="number"
+          value={loyalty}
+          onChange={e => setLoyalty(parseFloat(e.target.value) || 0)}
+          placeholder="Loyalty points"
+          className="border p-2 w-full"
+        />
+        <input
+          value={promo}
+          onChange={e => setPromo(e.target.value)}
+          placeholder="Promotion code"
+          className="border p-2 w-full"
+        />
+      </div>
+
+      <div className="border-t pt-2 space-y-1">
+        <div>Subtotal: {subtotal.toFixed(2)}</div>
+        <div>Discount: -{discountAmount.toFixed(2)}</div>
+        {promoAmount > 0 && <div>Promotion: -{promoAmount.toFixed(2)}</div>}
+        {loyaltyAmount > 0 && <div>Loyalty: -{loyaltyAmount.toFixed(2)}</div>}
+        <div>Tax: {taxAmount.toFixed(2)}</div>
+        <div className="font-bold">Total: {total.toFixed(2)}</div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={() => shareInvoice('print')}
+          className="px-3 py-2 bg-gray-200 rounded"
+        >
+          Print
+        </button>
+        <button
+          onClick={() => shareInvoice('whatsapp')}
+          className="px-3 py-2 bg-green-500 text-white rounded"
+        >
+          WhatsApp
+        </button>
+        <button
+          onClick={() => shareInvoice('sms')}
+          className="px-3 py-2 bg-blue-500 text-white rounded"
+        >
+          SMS
+        </button>
+        <button
+          onClick={() => shareInvoice('email')}
+          className="px-3 py-2 bg-indigo-500 text-white rounded"
+        >
+          Email
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default POSBase;

--- a/next_frontend_web/src/components/ERP/Sales/SalesHistory.tsx
+++ b/next_frontend_web/src/components/ERP/Sales/SalesHistory.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useAppState } from '../../../context/MainContext';
+
+const SalesHistory: React.FC = () => {
+  const state = useAppState(s => s);
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold mb-4">Sales History</h2>
+      <table className="w-full text-left border">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1">Sale #</th>
+            <th className="border px-2 py-1">Date</th>
+            <th className="border px-2 py-1">Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {state.recentSales.map(sale => (
+            <tr key={sale._id}>
+              <td className="border px-2 py-1">{sale.saleNumber}</td>
+              <td className="border px-2 py-1">{sale.date ? new Date(sale.date).toLocaleString() : ''}</td>
+              <td className="border px-2 py-1">{sale.total.toFixed(2)}</td>
+            </tr>
+          ))}
+          {state.recentSales.length === 0 && (
+            <tr>
+              <td className="border px-2 py-1 text-center" colSpan={3}>
+                No sales yet.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default SalesHistory;

--- a/next_frontend_web/src/pages/sales/history.tsx
+++ b/next_frontend_web/src/pages/sales/history.tsx
@@ -1,0 +1,13 @@
+import MainLayout from '../../components/Layout/MainLayout';
+import SalesHistory from '../../components/ERP/Sales/SalesHistory';
+import RoleGuard from '../../components/Auth/RoleGuard';
+
+const SalesHistoryPage: React.FC = () => (
+  <RoleGuard roles={['admin', 'manager']}>
+    <MainLayout>
+      <SalesHistory />
+    </MainLayout>
+  </RoleGuard>
+);
+
+export default SalesHistoryPage;

--- a/next_frontend_web/src/pages/sales/invoice.tsx
+++ b/next_frontend_web/src/pages/sales/invoice.tsx
@@ -1,0 +1,13 @@
+import MainLayout from '../../components/Layout/MainLayout';
+import InvoiceView from '../../components/ERP/Sales/InvoiceView';
+import RoleGuard from '../../components/Auth/RoleGuard';
+
+const InvoicePage: React.FC = () => (
+  <RoleGuard roles={['admin', 'manager']}>
+    <MainLayout>
+      <InvoiceView />
+    </MainLayout>
+  </RoleGuard>
+);
+
+export default InvoicePage;

--- a/next_frontend_web/src/pages/sales/quick.tsx
+++ b/next_frontend_web/src/pages/sales/quick.tsx
@@ -1,0 +1,13 @@
+import MainLayout from '../../components/Layout/MainLayout';
+import ClassicPOS from '../../components/ERP/Sales/ClassicPOS';
+import RoleGuard from '../../components/Auth/RoleGuard';
+
+const QuickSalesPage: React.FC = () => (
+  <RoleGuard roles={['admin', 'manager']}>
+    <MainLayout>
+      <ClassicPOS />
+    </MainLayout>
+  </RoleGuard>
+);
+
+export default QuickSalesPage;

--- a/next_frontend_web/src/pages/sales/returns.tsx
+++ b/next_frontend_web/src/pages/sales/returns.tsx
@@ -1,0 +1,13 @@
+import MainLayout from '../../components/Layout/MainLayout';
+import ModernPOS from '../../components/ERP/Sales/ModernPOS';
+import RoleGuard from '../../components/Auth/RoleGuard';
+
+const ReturnsPage: React.FC = () => (
+  <RoleGuard roles={['admin', 'manager']}>
+    <MainLayout>
+      <ModernPOS mode="return" />
+    </MainLayout>
+  </RoleGuard>
+);
+
+export default ReturnsPage;


### PR DESCRIPTION
## Summary
- add Classic and Modern POS components with barcode, discounts, tax, loyalty, and sharing
- introduce sales pages for quick sales, returns, history, and invoice views

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c1653604832c96caf82abebc2678