### PR TITLE
Add accounting pages and services

### DIFF
--- a/next_frontend_web/src/components/ERP/Accounting/CashRegister.tsx
+++ b/next_frontend_web/src/components/ERP/Accounting/CashRegister.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+import { accounting } from '../../../services';
+import { CashRegister } from '../../../types/accounting';
+
+const CashRegister: React.FC = () => {
+  const [registers, setRegisters] = useState<CashRegister[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    accounting
+      .getCashRegisters()
+      .then((data) => setRegisters(data))
+      .catch((err) => setError(err.message));
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Cash Register</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <ul className="space-y-2">
+        {registers.map((r) => (
+          <li key={r.id} className="border p-2 rounded">
+            <div>Opened: {new Date(r.openedAt).toLocaleString()}</div>
+            {r.closedAt && (
+              <div>Closed: {new Date(r.closedAt).toLocaleString()}</div>
+            )}
+            <div>Opening Balance: {r.openingBalance}</div>
+            {r.closingBalance !== undefined && (
+              <div>Closing Balance: {r.closingBalance}</div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default CashRegister;

--- a/next_frontend_web/src/components/ERP/Accounting/LedgerView.tsx
+++ b/next_frontend_web/src/components/ERP/Accounting/LedgerView.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { accounting } from '../../../services';
+import { LedgerEntry } from '../../../types/accounting';
+
+interface AccountBalance {
+  accountId: number;
+  accountName: string;
+  balance: number;
+}
+
+const LedgerView: React.FC = () => {
+  const [balances, setBalances] = useState<AccountBalance[]>([]);
+  const [entries, setEntries] = useState<LedgerEntry[]>([]);
+
+  useEffect(() => {
+    accounting.getLedgerBalances().then((data) => setBalances(data));
+  }, []);
+
+  const loadEntries = (accountId: number) => {
+    accounting
+      .getLedgerEntries(accountId)
+      .then((data) => setEntries(data));
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Ledger</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <h2 className="font-semibold mb-2">Accounts</h2>
+          <ul className="space-y-2">
+            {balances.map((b) => (
+              <li
+                key={b.accountId}
+                className="border p-2 rounded cursor-pointer"
+                onClick={() => loadEntries(b.accountId)}
+              >
+                {b.accountName}: {b.balance}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">Entries</h2>
+          <ul className="space-y-2">
+            {entries.map((e) => (
+              <li key={e.id} className="border p-2 rounded">
+                <div>{new Date(e.entryDate).toLocaleDateString()}</div>
+                <div>
+                  Debit: {e.debit} Credit: {e.credit} Balance: {e.balance}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LedgerView;

--- a/next_frontend_web/src/components/ERP/Accounting/VoucherEntry.tsx
+++ b/next_frontend_web/src/components/ERP/Accounting/VoucherEntry.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { accounting } from '../../../services';
+
+const VoucherEntry: React.FC = () => {
+  const [type, setType] = useState('payment');
+  const [amount, setAmount] = useState(0);
+  const [description, setDescription] = useState('');
+  const [message, setMessage] = useState('');
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await accounting.createVoucher(type, { amount, description });
+      setMessage('Voucher created');
+      setAmount(0);
+      setDescription('');
+    } catch (err: any) {
+      setMessage(err.message);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Voucher Entry</h1>
+      {message && <p>{message}</p>}
+      <div>
+        <label className="block mb-1">Type</label>
+        <select value={type} onChange={(e) => setType(e.target.value)} className="border p-2">
+          <option value="payment">Payment</option>
+          <option value="receipt">Receipt</option>
+          <option value="journal">Journal</option>
+        </select>
+      </div>
+      <div>
+        <label className="block mb-1">Amount</label>
+        <input
+          type="number"
+          value={amount}
+          onChange={(e) => setAmount(parseFloat(e.target.value))}
+          className="border p-2 w-full"
+        />
+      </div>
+      <div>
+        <label className="block mb-1">Description</label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="border p-2 w-full"
+        />
+      </div>
+      <button type="submit" className="bg-red-600 text-white px-4 py-2 rounded">
+        Save Voucher
+      </button>
+    </form>
+  );
+};
+
+export default VoucherEntry;

--- a/next_frontend_web/src/pages/accounting/cash-register.tsx
+++ b/next_frontend_web/src/pages/accounting/cash-register.tsx
@@ -1,0 +1,13 @@
+import MainLayout from '../../components/Layout/MainLayout';
+import RoleGuard from '../../components/Auth/RoleGuard';
+import CashRegister from '../../components/ERP/Accounting/CashRegister';
+
+const CashRegisterPage: React.FC = () => (
+  <RoleGuard roles={['admin', 'manager']}>
+    <MainLayout>
+      <CashRegister />
+    </MainLayout>
+  </RoleGuard>
+);
+
+export default CashRegisterPage;

--- a/next_frontend_web/src/pages/accounting/ledger.tsx
+++ b/next_frontend_web/src/pages/accounting/ledger.tsx
@@ -1,0 +1,13 @@
+import MainLayout from '../../components/Layout/MainLayout';
+import RoleGuard from '../../components/Auth/RoleGuard';
+import LedgerView from '../../components/ERP/Accounting/LedgerView';
+
+const LedgerPage: React.FC = () => (
+  <RoleGuard roles={['admin', 'manager']}>
+    <MainLayout>
+      <LedgerView />
+    </MainLayout>
+  </RoleGuard>
+);
+
+export default LedgerPage;

--- a/next_frontend_web/src/pages/accounting/voucher-entry.tsx
+++ b/next_frontend_web/src/pages/accounting/voucher-entry.tsx
@@ -1,0 +1,13 @@
+import MainLayout from '../../components/Layout/MainLayout';
+import RoleGuard from '../../components/Auth/RoleGuard';
+import VoucherEntry from '../../components/ERP/Accounting/VoucherEntry';
+
+const VoucherEntryPage: React.FC = () => (
+  <RoleGuard roles={['admin', 'manager']}>
+    <MainLayout>
+      <VoucherEntry />
+    </MainLayout>
+  </RoleGuard>
+);
+
+export default VoucherEntryPage;

--- a/next_frontend_web/src/services/accounting.ts
+++ b/next_frontend_web/src/services/accounting.ts
@@ -1,0 +1,33 @@
+import api from './apiClient';
+import { CashRegister, Voucher, LedgerEntry } from '../types/accounting';
+
+// Cash Register
+export const getCashRegisters = () =>
+  api.get<CashRegister[]>('/api/v1/cash-registers');
+
+export const openCashRegister = (payload: { openingBalance: number }) =>
+  api.post<{ registerId: number }>(
+    '/api/v1/cash-registers/open',
+    payload
+  );
+
+export const closeCashRegister = (payload: { closingBalance: number }) =>
+  api.post<void>('/api/v1/cash-registers/close', payload);
+
+export const recordCashTally = (payload: { count: number; notes?: string }) =>
+  api.post<void>('/api/v1/cash-registers/tally', payload);
+
+// Vouchers
+export const listVouchers = () =>
+  api.get<Voucher[]>('/api/v1/vouchers');
+
+export const createVoucher = (type: string, payload: any) =>
+  api.post<{ voucherId: number }>(`/api/v1/vouchers/${type}`, payload);
+
+// Ledger
+export const getLedgerBalances = () =>
+  api.get<any[]>('/api/v1/ledgers');
+
+export const getLedgerEntries = (
+  accountId: number | string
+) => api.get<LedgerEntry[]>(`/api/v1/ledgers/${accountId}/entries`);

--- a/next_frontend_web/src/services/index.ts
+++ b/next_frontend_web/src/services/index.ts
@@ -8,3 +8,4 @@ export * as dashboard from './dashboard';
 export * as inventory from './inventory';
 export * as purchases from './purchases';
 export * as suppliers from './suppliers';
+export * as accounting from './accounting';

--- a/next_frontend_web/src/types/accounting.ts
+++ b/next_frontend_web/src/types/accounting.ts
@@ -1,0 +1,25 @@
+export interface CashRegister {
+  id: number;
+  openingBalance: number;
+  closingBalance?: number;
+  openedAt: string;
+  closedAt?: string;
+}
+
+export interface Voucher {
+  id: number;
+  type: string;
+  amount: number;
+  description?: string;
+  createdAt: string;
+}
+
+export interface LedgerEntry {
+  id: number;
+  accountId: number;
+  accountName: string;
+  debit: number;
+  credit: number;
+  balance: number;
+  entryDate: string;
+}


### PR DESCRIPTION
## Summary
- add accounting service for cash registers, vouchers and ledger queries
- create accounting components and pages for cash register, voucher entry and ledger view
- export accounting APIs for use across frontend

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ab182190832ca1a1778a21436236