### PR TITLE
Add report pages and dashboard drill-down links

### DIFF
--- a/next_frontend_web/package.json
+++ b/next_frontend_web/package.json
@@ -25,7 +25,9 @@
     "react-dom": "18.2.0",
     "typescript": "5.2.2",
     "next-i18next": "^15.2.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "jspdf": "^2.5.1",
+    "jspdf-autotable": "^3.5.23"
   },
   "devDependencies": {
     "autoprefixer": "10.4.16",

--- a/next_frontend_web/src/components/ERP/Dashboard.tsx
+++ b/next_frontend_web/src/components/ERP/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
 import { useAppState, useAppDispatch } from '../../context/MainContext';
 import { useAuth } from '../../context/AuthContext';
 import ErrorDisplay from '../Misc/ErrorDisplay';
@@ -242,85 +243,93 @@ const Dashboard: React.FC = () => {
 
       {/* Key Metrics */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-        <div className="bg-white dark:bg-gray-900 rounded-xl p-6 border border-gray-200 dark:border-gray-700 shadow-sm">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Today's Revenue</p>
-              <p className="text-2xl font-bold text-gray-800 dark:text-white">
-                {formatCurrency(stats?.todayRevenue || 0)}
-              </p>
-              <div className="flex items-center mt-2">
-                <TrendingUp className="w-4 h-4 text-green-500 mr-1" />
-                <span className="text-sm text-green-600 dark:text-green-400">
-                  {stats?.todayOrders || 0} orders
-                </span>
+        <Link href="/reports/sales" className="block">
+          <div className="bg-white dark:bg-gray-900 rounded-xl p-6 border border-gray-200 dark:border-gray-700 shadow-sm cursor-pointer">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Today's Revenue</p>
+                <p className="text-2xl font-bold text-gray-800 dark:text-white">
+                  {formatCurrency(stats?.todayRevenue || 0)}
+                </p>
+                <div className="flex items-center mt-2">
+                  <TrendingUp className="w-4 h-4 text-green-500 mr-1" />
+                  <span className="text-sm text-green-600 dark:text-green-400">
+                    {stats?.todayOrders || 0} orders
+                  </span>
+                </div>
+              </div>
+              <div className="bg-gradient-to-r from-green-500 to-green-600 p-3 rounded-lg">
+                <DollarSign className="w-6 h-6 text-white" />
               </div>
             </div>
-            <div className="bg-gradient-to-r from-green-500 to-green-600 p-3 rounded-lg">
-              <DollarSign className="w-6 h-6 text-white" />
-            </div>
           </div>
-        </div>
+        </Link>
 
-        <div className="bg-white dark:bg-gray-900 rounded-xl p-6 border border-gray-200 dark:border-gray-700 shadow-sm">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Total Products</p>
-              <p className="text-2xl font-bold text-gray-800 dark:text-white">
-                {stats?.totalProducts || 0}
-              </p>
-              <div className="flex items-center mt-2">
-                <Package className="w-4 h-4 text-blue-500 mr-1" />
-                <span className="text-sm text-blue-600 dark:text-blue-400">
-                  {formatCurrency(stats?.totalInventoryValue || 0)} value
-                </span>
+        <Link href="/reports/inventory" className="block">
+          <div className="bg-white dark:bg-gray-900 rounded-xl p-6 border border-gray-200 dark:border-gray-700 shadow-sm cursor-pointer">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Total Products</p>
+                <p className="text-2xl font-bold text-gray-800 dark:text-white">
+                  {stats?.totalProducts || 0}
+                </p>
+                <div className="flex items-center mt-2">
+                  <Package className="w-4 h-4 text-blue-500 mr-1" />
+                  <span className="text-sm text-blue-600 dark:text-blue-400">
+                    {formatCurrency(stats?.totalInventoryValue || 0)} value
+                  </span>
+                </div>
+              </div>
+              <div className="bg-gradient-to-r from-blue-500 to-blue-600 p-3 rounded-lg">
+                <Package className="w-6 h-6 text-white" />
               </div>
             </div>
-            <div className="bg-gradient-to-r from-blue-500 to-blue-600 p-3 rounded-lg">
-              <Package className="w-6 h-6 text-white" />
-            </div>
           </div>
-        </div>
+        </Link>
 
-        <div className="bg-white dark:bg-gray-900 rounded-xl p-6 border border-gray-200 dark:border-gray-700 shadow-sm">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Total Customers</p>
-              <p className="text-2xl font-bold text-gray-800 dark:text-white">
-                {stats?.totalCustomers || 0}
-              </p>
-              <div className="flex items-center mt-2">
-                <CreditCard className="w-4 h-4 text-purple-500 mr-1" />
-                <span className="text-sm text-purple-600 dark:text-purple-400">
-                  {formatCurrency(stats?.creditOutstanding || 0)} credit
-                </span>
+        <Link href="/reports/customers" className="block">
+          <div className="bg-white dark:bg-gray-900 rounded-xl p-6 border border-gray-200 dark:border-gray-700 shadow-sm cursor-pointer">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Total Customers</p>
+                <p className="text-2xl font-bold text-gray-800 dark:text-white">
+                  {stats?.totalCustomers || 0}
+                </p>
+                <div className="flex items-center mt-2">
+                  <CreditCard className="w-4 h-4 text-purple-500 mr-1" />
+                  <span className="text-sm text-purple-600 dark:text-purple-400">
+                    {formatCurrency(stats?.creditOutstanding || 0)} credit
+                  </span>
+                </div>
+              </div>
+              <div className="bg-gradient-to-r from-purple-500 to-purple-600 p-3 rounded-lg">
+                <Users className="w-6 h-6 text-white" />
               </div>
             </div>
-            <div className="bg-gradient-to-r from-purple-500 to-purple-600 p-3 rounded-lg">
-              <Users className="w-6 h-6 text-white" />
-            </div>
           </div>
-        </div>
+        </Link>
 
-        <div className="bg-white dark:bg-gray-900 rounded-xl p-6 border border-gray-200 dark:border-gray-700 shadow-sm">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Low Stock Items</p>
-              <p className="text-2xl font-bold text-gray-800 dark:text-white">
-                {stats?.lowStockCount || 0}
-              </p>
-              <div className="flex items-center mt-2">
-                <AlertTriangle className="w-4 h-4 text-yellow-500 mr-1" />
-                <span className="text-sm text-yellow-600 dark:text-yellow-400">
-                  Needs attention
-                </span>
+        <Link href="/reports/inventory" className="block">
+          <div className="bg-white dark:bg-gray-900 rounded-xl p-6 border border-gray-200 dark:border-gray-700 shadow-sm cursor-pointer">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Low Stock Items</p>
+                <p className="text-2xl font-bold text-gray-800 dark:text-white">
+                  {stats?.lowStockCount || 0}
+                </p>
+                <div className="flex items-center mt-2">
+                  <AlertTriangle className="w-4 h-4 text-yellow-500 mr-1" />
+                  <span className="text-sm text-yellow-600 dark:text-yellow-400">
+                    Needs attention
+                  </span>
+                </div>
+              </div>
+              <div className="bg-gradient-to-r from-yellow-500 to-yellow-600 p-3 rounded-lg">
+                <AlertTriangle className="w-6 h-6 text-white" />
               </div>
             </div>
-            <div className="bg-gradient-to-r from-yellow-500 to-yellow-600 p-3 rounded-lg">
-              <AlertTriangle className="w-6 h-6 text-white" />
-            </div>
           </div>
-        </div>
+        </Link>
       </div>
 
       {/* Charts and Lists */}
@@ -331,9 +340,12 @@ const Dashboard: React.FC = () => {
             <div className="p-6 border-b border-gray-200 dark:border-gray-700">
               <div className="flex items-center justify-between">
                 <h3 className="text-lg font-semibold text-gray-800 dark:text-white">Recent Sales</h3>
-                <button className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm font-medium">
+                <Link
+                  href="/reports/sales"
+                  className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm font-medium"
+                >
                   View All
-                </button>
+                </Link>
               </div>
             </div>
             <div className="p-6">
@@ -390,7 +402,15 @@ const Dashboard: React.FC = () => {
           {/* Top Products */}
           <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
             <div className="p-6 border-b border-gray-200 dark:border-gray-700">
-              <h3 className="text-lg font-semibold text-gray-800 dark:text-white">Top Products</h3>
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-gray-800 dark:text-white">Top Products</h3>
+                <Link
+                  href="/reports/sales"
+                  className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm font-medium"
+                >
+                  View All
+                </Link>
+              </div>
             </div>
             <div className="p-6">
               {stats?.topProducts && stats.topProducts.length > 0 ? (
@@ -430,10 +450,18 @@ const Dashboard: React.FC = () => {
           {/* Low Stock Alert */}
           <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
             <div className="p-6 border-b border-gray-200 dark:border-gray-700">
-              <h3 className="text-lg font-semibold text-gray-800 dark:text-white flex items-center">
-                <AlertTriangle className="w-5 h-5 text-yellow-500 mr-2" />
-                Low Stock Alert
-              </h3>
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-gray-800 dark:text-white flex items-center">
+                  <AlertTriangle className="w-5 h-5 text-yellow-500 mr-2" />
+                  Low Stock Alert
+                </h3>
+                <Link
+                  href="/reports/inventory"
+                  className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm font-medium"
+                >
+                  View All
+                </Link>
+              </div>
             </div>
             <div className="p-6">
             {stats?.lowStockProducts && stats.lowStockProducts.length > 0 ? (
@@ -476,3 +504,4 @@ const Dashboard: React.FC = () => {
 };
 
 export default Dashboard;
+

--- a/next_frontend_web/src/components/ERP/Reports/CustomersReport.tsx
+++ b/next_frontend_web/src/components/ERP/Reports/CustomersReport.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReportGenerator from './ReportGenerator';
+
+const CustomersReport: React.FC = () => (
+  <ReportGenerator
+    title="Customers Report"
+    endpoint="/api/v1/customers"
+    filename="customers-report"
+    columns={[
+      { key: 'name', label: 'Name' },
+      { key: 'email', label: 'Email' },
+      { key: 'creditBalance', label: 'Credit' }
+    ]}
+    dateField="createdAt"
+  />
+);
+
+export default CustomersReport;

--- a/next_frontend_web/src/components/ERP/Reports/InventoryReport.tsx
+++ b/next_frontend_web/src/components/ERP/Reports/InventoryReport.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReportGenerator from './ReportGenerator';
+
+const InventoryReport: React.FC = () => (
+  <ReportGenerator
+    title="Inventory Report"
+    endpoint="/api/v1/products"
+    filename="inventory-report"
+    columns={[
+      { key: 'sku', label: 'SKU' },
+      { key: 'name', label: 'Product' },
+      { key: 'stock', label: 'Stock' },
+      { key: 'price', label: 'Price' }
+    ]}
+    dateField="updatedAt"
+  />
+);
+
+export default InventoryReport;

--- a/next_frontend_web/src/components/ERP/Reports/ReportGenerator.tsx
+++ b/next_frontend_web/src/components/ERP/Reports/ReportGenerator.tsx
@@ -1,0 +1,140 @@
+import React, { useState, useEffect } from 'react';
+import api from '../../../services/apiClient';
+import { jsPDF } from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import * as XLSX from 'xlsx';
+
+interface Column {
+  key: string;
+  label: string;
+}
+
+interface ReportGeneratorProps {
+  title: string;
+  endpoint: string;
+  columns: Column[];
+  filename: string;
+  dateField?: string;
+}
+
+const ReportGenerator: React.FC<ReportGeneratorProps> = ({
+  title,
+  endpoint,
+  columns,
+  filename,
+  dateField = 'date'
+}) => {
+  const [data, setData] = useState<any[]>([]);
+  const [filtered, setFiltered] = useState<any[]>([]);
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const res = await api.get<any[]>(endpoint);
+        setData(res);
+        setFiltered(res);
+      } catch (err) {
+        console.error('Failed to load report data', err);
+      }
+    };
+    loadData();
+  }, [endpoint]);
+
+  const handleFilter = () => {
+    let result = data;
+    if (startDate) {
+      result = result.filter(item => new Date(item[dateField]) >= new Date(startDate));
+    }
+    if (endDate) {
+      result = result.filter(item => new Date(item[dateField]) <= new Date(endDate));
+    }
+    setFiltered(result);
+  };
+
+  const exportExcel = () => {
+    const ws = XLSX.utils.json_to_sheet(filtered);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Report');
+    XLSX.writeFile(wb, `${filename}.xlsx`);
+  };
+
+  const exportPdf = () => {
+    const doc = new jsPDF();
+    const tableColumn = columns.map(c => c.label);
+    const tableRows = filtered.map(row => columns.map(c => row[c.key]));
+    autoTable(doc, { head: [tableColumn], body: tableRows });
+    doc.save(`${filename}.pdf`);
+  };
+
+  return (
+    <div className="p-6 bg-gray-50 dark:bg-gray-950 min-h-full">
+      <h1 className="text-2xl font-bold text-gray-800 dark:text-white mb-4">{title}</h1>
+      <div className="flex items-end space-x-4 mb-4">
+        <div>
+          <label className="block text-sm text-gray-700 dark:text-gray-300 mb-1">From</label>
+          <input
+            type="date"
+            value={startDate}
+            onChange={e => setStartDate(e.target.value)}
+            className="border rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200"
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-gray-700 dark:text-gray-300 mb-1">To</label>
+          <input
+            type="date"
+            value={endDate}
+            onChange={e => setEndDate(e.target.value)}
+            className="border rounded px-2 py-1 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200"
+          />
+        </div>
+        <button
+          onClick={handleFilter}
+          className="bg-red-600 text-white px-4 py-2 rounded"
+        >
+          Filter
+        </button>
+        <button
+          onClick={exportPdf}
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          Export PDF
+        </button>
+        <button
+          onClick={exportExcel}
+          className="bg-green-600 text-white px-4 py-2 rounded"
+        >
+          Export Excel
+        </button>
+      </div>
+      <div className="overflow-x-auto">
+        <table id="report-table" className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-100 dark:bg-gray-800">
+            <tr>
+              {columns.map(col => (
+                <th key={col.key} className="px-4 py-2 text-left text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+            {filtered.map((row, idx) => (
+              <tr key={idx}>
+                {columns.map(col => (
+                  <td key={col.key} className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300">
+                    {row[col.key]}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default ReportGenerator;

--- a/next_frontend_web/src/components/ERP/Reports/SalesReport.tsx
+++ b/next_frontend_web/src/components/ERP/Reports/SalesReport.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import ReportGenerator from './ReportGenerator';
+
+const SalesReport: React.FC = () => (
+  <ReportGenerator
+    title="Sales Report"
+    endpoint="/api/v1/sales"
+    filename="sales-report"
+    columns={[
+      { key: 'saleNumber', label: 'Sale #' },
+      { key: 'date', label: 'Date' },
+      { key: 'total', label: 'Total' }
+    ]}
+    dateField="date"
+  />
+);
+
+export default SalesReport;

--- a/next_frontend_web/src/pages/reports/customers.tsx
+++ b/next_frontend_web/src/pages/reports/customers.tsx
@@ -1,0 +1,13 @@
+import MainLayout from '../../components/Layout/MainLayout';
+import CustomersReport from '../../components/ERP/Reports/CustomersReport';
+import RoleGuard from '../../components/Auth/RoleGuard';
+
+const CustomersReportPage: React.FC = () => (
+  <RoleGuard roles={['admin', 'manager']}>
+    <MainLayout>
+      <CustomersReport />
+    </MainLayout>
+  </RoleGuard>
+);
+
+export default CustomersReportPage;

--- a/next_frontend_web/src/pages/reports/inventory.tsx
+++ b/next_frontend_web/src/pages/reports/inventory.tsx
@@ -1,0 +1,13 @@
+import MainLayout from '../../components/Layout/MainLayout';
+import InventoryReport from '../../components/ERP/Reports/InventoryReport';
+import RoleGuard from '../../components/Auth/RoleGuard';
+
+const InventoryReportPage: React.FC = () => (
+  <RoleGuard roles={['admin', 'manager']}>
+    <MainLayout>
+      <InventoryReport />
+    </MainLayout>
+  </RoleGuard>
+);
+
+export default InventoryReportPage;

--- a/next_frontend_web/src/pages/reports/sales.tsx
+++ b/next_frontend_web/src/pages/reports/sales.tsx
@@ -1,0 +1,13 @@
+import MainLayout from '../../components/Layout/MainLayout';
+import SalesReport from '../../components/ERP/Reports/SalesReport';
+import RoleGuard from '../../components/Auth/RoleGuard';
+
+const SalesReportPage: React.FC = () => (
+  <RoleGuard roles={['admin', 'manager']}>
+    <MainLayout>
+      <SalesReport />
+    </MainLayout>
+  </RoleGuard>
+);
+
+export default SalesReportPage;


### PR DESCRIPTION
## Summary
- add generic `ReportGenerator` with filtering and PDF/Excel export
- create sales, inventory, and customers report pages
- link dashboard widgets and lists to new report pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ad2e7310832cba67e83b55401fb2