### PR TITLE
feat: add HR module pages and payroll ledger

### DIFF
--- a/next_frontend_web/src/components/ERP/HR/ClockInOut.tsx
+++ b/next_frontend_web/src/components/ERP/HR/ClockInOut.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { Clock } from 'lucide-react';
+
+const ClockInOut: React.FC = () => {
+  const [records, setRecords] = useState<{ type: 'in' | 'out'; time: string }[]>([]);
+
+  const handleClock = (type: 'in' | 'out') => {
+    const time = new Date().toLocaleString();
+    setRecords(prev => [...prev, { type, time }]);
+  };
+
+  return (
+    <div className="p-4">
+      <div className="flex items-center space-x-2 mb-4">
+        <Clock className="w-6 h-6" />
+        <h2 className="text-xl font-semibold">Clock In/Out</h2>
+      </div>
+      <div className="space-x-4 mb-4">
+        <button
+          onClick={() => handleClock('in')}
+          className="px-4 py-2 bg-green-500 text-white rounded"
+        >
+          Clock In
+        </button>
+        <button
+          onClick={() => handleClock('out')}
+          className="px-4 py-2 bg-red-500 text-white rounded"
+        >
+          Clock Out
+        </button>
+      </div>
+      <ul className="space-y-1">
+        {records.map((r, i) => (
+          <li key={i} className="text-sm">
+            {r.type === 'in' ? 'In' : 'Out'} at {r.time}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ClockInOut;

--- a/next_frontend_web/src/components/ERP/HR/LeaveCalendar.tsx
+++ b/next_frontend_web/src/components/ERP/HR/LeaveCalendar.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { Calendar } from 'lucide-react';
+
+interface Leave {
+  date: string;
+  reason: string;
+}
+
+const LeaveCalendar: React.FC = () => {
+  const [leaves, setLeaves] = useState<Leave[]>([]);
+  const [form, setForm] = useState<Leave>({ date: '', reason: '' });
+
+  const addLeave = () => {
+    if (form.date) {
+      setLeaves(prev => [...prev, form]);
+      setForm({ date: '', reason: '' });
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <div className="flex items-center space-x-2 mb-4">
+        <Calendar className="w-6 h-6" />
+        <h2 className="text-xl font-semibold">Leave Calendar</h2>
+      </div>
+      <div className="flex space-x-2 mb-4">
+        <input
+          type="date"
+          className="border rounded px-2"
+          value={form.date}
+          onChange={e => setForm({ ...form, date: e.target.value })}
+        />
+        <input
+          type="text"
+          placeholder="Reason"
+          className="border rounded px-2"
+          value={form.reason}
+          onChange={e => setForm({ ...form, reason: e.target.value })}
+        />
+        <button
+          onClick={addLeave}
+          className="px-4 py-2 bg-blue-500 text-white rounded"
+        >
+          Add
+        </button>
+      </div>
+      <ul className="space-y-1">
+        {leaves.map((l, i) => (
+          <li key={i} className="text-sm">
+            {l.date}: {l.reason}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default LeaveCalendar;

--- a/next_frontend_web/src/components/ERP/HR/PayrollLedger.tsx
+++ b/next_frontend_web/src/components/ERP/HR/PayrollLedger.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+export interface LedgerEntry {
+  id: number;
+  employee: string;
+  amount: number;
+  date: string;
+}
+
+interface PayrollLedgerProps {
+  entries: LedgerEntry[];
+}
+
+const PayrollLedger: React.FC<PayrollLedgerProps> = ({ entries }) => (
+  <div className="mt-6">
+    <h3 className="text-lg font-semibold mb-2">Payroll Ledger</h3>
+    <table className="min-w-full border">
+      <thead>
+        <tr className="bg-gray-100">
+          <th className="px-2 py-1 border">Date</th>
+          <th className="px-2 py-1 border">Employee</th>
+          <th className="px-2 py-1 border">Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        {entries.map(entry => (
+          <tr key={entry.id}>
+            <td className="px-2 py-1 border">{entry.date}</td>
+            <td className="px-2 py-1 border">{entry.employee}</td>
+            <td className="px-2 py-1 border">${entry.amount.toFixed(2)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default PayrollLedger;

--- a/next_frontend_web/src/components/ERP/HR/SalaryProcessing.tsx
+++ b/next_frontend_web/src/components/ERP/HR/SalaryProcessing.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { DollarSign } from 'lucide-react';
+import PayrollLedger, { LedgerEntry } from './PayrollLedger';
+
+const SalaryProcessing: React.FC = () => {
+  const [entries, setEntries] = useState<LedgerEntry[]>([]);
+  const [form, setForm] = useState({ employee: '', amount: '' });
+
+  const processSalary = () => {
+    if (form.employee && form.amount) {
+      const newEntry: LedgerEntry = {
+        id: entries.length + 1,
+        employee: form.employee,
+        amount: parseFloat(form.amount),
+        date: new Date().toLocaleDateString(),
+      };
+      setEntries(prev => [...prev, newEntry]);
+      setForm({ employee: '', amount: '' });
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <div className="flex items-center space-x-2 mb-4">
+        <DollarSign className="w-6 h-6" />
+        <h2 className="text-xl font-semibold">Salary Processing</h2>
+      </div>
+      <div className="flex space-x-2 mb-4">
+        <input
+          type="text"
+          placeholder="Employee"
+          className="border rounded px-2"
+          value={form.employee}
+          onChange={e => setForm({ ...form, employee: e.target.value })}
+        />
+        <input
+          type="number"
+          placeholder="Amount"
+          className="border rounded px-2"
+          value={form.amount}
+          onChange={e => setForm({ ...form, amount: e.target.value })}
+        />
+        <button
+          onClick={processSalary}
+          className="px-4 py-2 bg-green-600 text-white rounded"
+        >
+          Process
+        </button>
+      </div>
+      <PayrollLedger entries={entries} />
+    </div>
+  );
+};
+
+export default SalaryProcessing;

--- a/next_frontend_web/src/pages/hr/clock.tsx
+++ b/next_frontend_web/src/pages/hr/clock.tsx
@@ -1,0 +1,13 @@
+import MainLayout from '../../components/Layout/MainLayout';
+import RoleGuard from '../../components/Auth/RoleGuard';
+import ClockInOut from '../../components/ERP/HR/ClockInOut';
+
+const ClockPage: React.FC = () => (
+  <RoleGuard roles={['admin', 'manager', 'employee']}>
+    <MainLayout>
+      <ClockInOut />
+    </MainLayout>
+  </RoleGuard>
+);
+
+export default ClockPage;

--- a/next_frontend_web/src/pages/hr/index.tsx
+++ b/next_frontend_web/src/pages/hr/index.tsx
@@ -1,0 +1,20 @@
+import MainLayout from '../../components/Layout/MainLayout';
+import RoleGuard from '../../components/Auth/RoleGuard';
+import Link from 'next/link';
+
+const HRDashboard: React.FC = () => (
+  <RoleGuard roles={['admin', 'manager', 'employee']}>
+    <MainLayout>
+      <div className="p-6 space-y-4">
+        <h1 className="text-2xl font-bold">Human Resources</h1>
+        <ul className="list-disc pl-6 space-y-1">
+          <li><Link href="/hr/clock" className="text-blue-600 hover:underline">Clock In/Out</Link></li>
+          <li><Link href="/hr/leave" className="text-blue-600 hover:underline">Leave Calendar</Link></li>
+          <li><Link href="/hr/payroll" className="text-blue-600 hover:underline">Salary Processing</Link></li>
+        </ul>
+      </div>
+    </MainLayout>
+  </RoleGuard>
+);
+
+export default HRDashboard;

--- a/next_frontend_web/src/pages/hr/leave.tsx
+++ b/next_frontend_web/src/pages/hr/leave.tsx
@@ -1,0 +1,13 @@
+import MainLayout from '../../components/Layout/MainLayout';
+import RoleGuard from '../../components/Auth/RoleGuard';
+import LeaveCalendar from '../../components/ERP/HR/LeaveCalendar';
+
+const LeavePage: React.FC = () => (
+  <RoleGuard roles={['admin', 'manager', 'employee']}>
+    <MainLayout>
+      <LeaveCalendar />
+    </MainLayout>
+  </RoleGuard>
+);
+
+export default LeavePage;

--- a/next_frontend_web/src/pages/hr/payroll.tsx
+++ b/next_frontend_web/src/pages/hr/payroll.tsx
@@ -1,0 +1,13 @@
+import MainLayout from '../../components/Layout/MainLayout';
+import RoleGuard from '../../components/Auth/RoleGuard';
+import SalaryProcessing from '../../components/ERP/HR/SalaryProcessing';
+
+const PayrollPage: React.FC = () => (
+  <RoleGuard roles={['admin', 'manager', 'employee']}>
+    <MainLayout>
+      <SalaryProcessing />
+    </MainLayout>
+  </RoleGuard>
+);
+
+export default PayrollPage;


### PR DESCRIPTION
## Summary
- add clock-in/out, leave calendar, and salary processing components
- expose HR pages with links to new features
- integrate a simple payroll ledger for auditing salary transactions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: sh: 1: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a5e616d7b8832cae300293fec90743