### PR TITLE
Add settings pages and backend session controls

### DIFF
--- a/go_backend_rmt/internal/handlers/auth.go
+++ b/go_backend_rmt/internal/handlers/auth.go
@@ -50,9 +50,17 @@ func (h *AuthHandler) Login(c *gin.Context) {
 
 // POST /auth/logout
 func (h *AuthHandler) Logout(c *gin.Context) {
-	// In a stateless JWT system, logout is handled client-side
-	// Here you could implement token blacklisting if needed
-	utils.SuccessResponse(c, "Logout successful", nil)
+       userID := c.GetInt("user_id")
+       sessionID := c.GetString("session_id")
+       if userID == 0 || sessionID == "" {
+               utils.ForbiddenResponse(c, "User session not found")
+               return
+       }
+       if err := h.authService.Logout(userID, sessionID); err != nil {
+               utils.ErrorResponse(c, http.StatusInternalServerError, "Failed to logout", err)
+               return
+       }
+       utils.SuccessResponse(c, "Logout successful", nil)
 }
 
 // POST /auth/refresh-token

--- a/go_backend_rmt/internal/middleware/auth.go
+++ b/go_backend_rmt/internal/middleware/auth.go
@@ -67,28 +67,29 @@ func RequireAuth() gin.HandlerFunc {
 		if claims.RoleID != nil {
 			c.Set("role_id", *claims.RoleID)
 		}
-		c.Set("user", user)
+               c.Set("user", user)
 
-		// Update device session activity if session ID is present
-		if claims.SessionID != "" {
-			db := database.GetDB()
-			ipAddr := c.ClientIP()
-			ua := c.GetHeader("User-Agent")
-			var ipVal interface{}
-			if ipAddr != "" {
-				ipVal = ipAddr
-			}
-			var uaVal interface{}
-			if ua != "" {
-				uaVal = ua
-			}
-			_, err := db.Exec(`UPDATE device_sessions SET last_seen = NOW(), ip_address = COALESCE($2, ip_address), user_agent = COALESCE($3, user_agent) WHERE session_id = $1`, claims.SessionID, ipVal, uaVal)
-			if err != nil {
-				log.Printf("Failed to update device session %s: %v", claims.SessionID, err)
-			}
-		} else {
-			log.Println("No session ID in JWT claims")
-		}
+               // Update device session activity if session ID is present
+               if claims.SessionID != "" {
+                       c.Set("session_id", claims.SessionID)
+                       db := database.GetDB()
+                       ipAddr := c.ClientIP()
+                       ua := c.GetHeader("User-Agent")
+                       var ipVal interface{}
+                       if ipAddr != "" {
+                               ipVal = ipAddr
+                       }
+                       var uaVal interface{}
+                       if ua != "" {
+                               uaVal = ua
+                       }
+                       _, err := db.Exec(`UPDATE device_sessions SET last_seen = NOW(), ip_address = COALESCE($2, ip_address), user_agent = COALESCE($3, user_agent) WHERE session_id = $1`, claims.SessionID, ipVal, uaVal)
+                       if err != nil {
+                               log.Printf("Failed to update device session %s: %v", claims.SessionID, err)
+                       }
+               } else {
+                       log.Println("No session ID in JWT claims")
+               }
 
 		c.Next()
 	}

--- a/go_backend_rmt/internal/services/auth_service.go
+++ b/go_backend_rmt/internal/services/auth_service.go
@@ -13,7 +13,7 @@ import (
 )
 
 type AuthService struct {
-	db *sql.DB
+        db *sql.DB
 }
 
 func NewAuthService() *AuthService {
@@ -154,6 +154,18 @@ func (s *AuthService) Login(req *models.LoginRequest, ipAddress, userAgent strin
 		SessionID:    sessionID,
 		User:         userResponse,
 	}, nil
+}
+
+// Logout deactivates a device session for the given user
+func (s *AuthService) Logout(userID int, sessionID string) error {
+       if sessionID == "" {
+               return fmt.Errorf("session ID required")
+       }
+       _, err := s.db.Exec(`UPDATE device_sessions SET is_active=FALSE WHERE user_id=$1 AND session_id=$2`, userID, sessionID)
+       if err != nil {
+               return fmt.Errorf("failed to revoke session: %w", err)
+       }
+       return nil
 }
 
 func (s *AuthService) RefreshToken(req *models.RefreshTokenRequest) (*models.RefreshTokenResponse, error) {

--- a/next_frontend_web/src/pages/settings/backup.tsx
+++ b/next_frontend_web/src/pages/settings/backup.tsx
@@ -1,0 +1,8 @@
+export default function BackupSettings() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Backup Settings</h1>
+      <p>Configure automatic backups and restore options.</p>
+    </div>
+  );
+}

--- a/next_frontend_web/src/pages/settings/company.tsx
+++ b/next_frontend_web/src/pages/settings/company.tsx
@@ -1,0 +1,8 @@
+export default function CompanySettings() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Company Settings</h1>
+      <p>Manage company details and preferences here.</p>
+    </div>
+  );
+}

--- a/next_frontend_web/src/pages/settings/devices.tsx
+++ b/next_frontend_web/src/pages/settings/devices.tsx
@@ -1,0 +1,8 @@
+export default function DeviceSettings() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Device Management</h1>
+      <p>View connected devices and enforce session limits.</p>
+    </div>
+  );
+}

--- a/next_frontend_web/src/pages/settings/index.tsx
+++ b/next_frontend_web/src/pages/settings/index.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+export default function SettingsHome() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Settings</h1>
+      <ul className="list-disc pl-5 space-y-1">
+        <li><Link href="/settings/company">Company</Link></li>
+        <li><Link href="/settings/locations">Locations</Link></li>
+        <li><Link href="/settings/users">Users</Link></li>
+        <li><Link href="/settings/devices">Devices</Link></li>
+        <li><Link href="/settings/backup">Backup</Link></li>
+        <li><Link href="/settings/integrations">Integrations</Link></li>
+        <li><Link href="/settings/pos">POS &amp; Printer Setup</Link></li>
+      </ul>
+    </div>
+  );
+}

--- a/next_frontend_web/src/pages/settings/integrations.tsx
+++ b/next_frontend_web/src/pages/settings/integrations.tsx
@@ -1,0 +1,8 @@
+export default function IntegrationSettings() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Integrations</h1>
+      <p>Connect third-party services and configure integrations.</p>
+    </div>
+  );
+}

--- a/next_frontend_web/src/pages/settings/locations.tsx
+++ b/next_frontend_web/src/pages/settings/locations.tsx
@@ -1,0 +1,8 @@
+export default function LocationSettings() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Location Settings</h1>
+      <p>Configure locations and branches for your company.</p>
+    </div>
+  );
+}

--- a/next_frontend_web/src/pages/settings/pos.tsx
+++ b/next_frontend_web/src/pages/settings/pos.tsx
@@ -1,0 +1,8 @@
+export default function PosSettings() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">POS &amp; Printer Setup</h1>
+      <p>Configure point-of-sale hardware and printer options.</p>
+    </div>
+  );
+}

--- a/next_frontend_web/src/pages/settings/users.tsx
+++ b/next_frontend_web/src/pages/settings/users.tsx
@@ -1,0 +1,8 @@
+export default function UserSettings() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">User Management</h1>
+      <p>Invite, edit, and manage users and roles.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder settings pages for company, locations, users, devices, backup, integrations, and POS/printer setup
- implement server-side logout by deactivating device sessions and exposing session IDs in auth middleware

## Testing
- `go test ./...`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a5e87b1418832ca5c5877349063dda