### PR TITLE
feat: add role-based access control

### DIFF
--- a/next_frontend_web/src/components/Auth/RoleGuard.tsx
+++ b/next_frontend_web/src/components/Auth/RoleGuard.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 
 interface RoleGuardProps {
-  roles: Array<'admin' | 'manager' | 'user'>;
+  roles: string[];
   children: ReactNode;
 }
 

--- a/next_frontend_web/src/components/Layout/Sidebar.tsx
+++ b/next_frontend_web/src/components/Layout/Sidebar.tsx
@@ -134,7 +134,7 @@ const Sidebar: React.FC = () => {
     {
       icon: UserCheck,
       label: 'HR',
-      roles: ['Admin', 'Manager', 'HR'],
+      roles: ['Admin', 'HR'],
       subItems: [
         { label: 'Employees', view: 'employees', icon: Users },
         { label: 'Attendance', view: 'attendance', icon: History },

--- a/next_frontend_web/src/context/AuthContext.tsx
+++ b/next_frontend_web/src/context/AuthContext.tsx
@@ -99,14 +99,36 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     dispatch({ type: 'UPDATE_USER_LANGUAGES', payload });
   };
 
+  const role = state.user?.role;
+  const permissions = state.user?.permissions || [];
+
   const hasRole = (roles: string | string[]) => {
-    if (!state.user) return false;
+    if (!role) return false;
     const roleList = Array.isArray(roles) ? roles : [roles];
-    return roleList.includes(state.user.role);
+    return roleList.map(r => r.toLowerCase()).includes(role.toLowerCase());
+  };
+
+  const hasPermission = (perms: string | string[]) => {
+    if (!permissions.length) return false;
+    const permList = Array.isArray(perms) ? perms : [perms];
+    return permList.some(p => permissions.includes(p));
   };
 
   return (
-    <AuthContext.Provider value={{ state, login, register, logout, clearError, hasRole, updateUserLanguages }}>
+    <AuthContext.Provider
+      value={{
+        state,
+        login,
+        register,
+        logout,
+        clearError,
+        hasRole,
+        hasPermission,
+        role,
+        permissions,
+        updateUserLanguages,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/next_frontend_web/src/pages/hr/clock.tsx
+++ b/next_frontend_web/src/pages/hr/clock.tsx
@@ -3,7 +3,7 @@ import RoleGuard from '../../components/Auth/RoleGuard';
 import ClockInOut from '../../components/ERP/HR/ClockInOut';
 
 const ClockPage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager', 'employee']}>
+  <RoleGuard roles={['Admin', 'HR']}>
     <MainLayout>
       <ClockInOut />
     </MainLayout>

--- a/next_frontend_web/src/pages/hr/index.tsx
+++ b/next_frontend_web/src/pages/hr/index.tsx
@@ -3,7 +3,7 @@ import RoleGuard from '../../components/Auth/RoleGuard';
 import Link from 'next/link';
 
 const HRDashboard: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager', 'employee']}>
+  <RoleGuard roles={['Admin', 'HR']}>
     <MainLayout>
       <div className="p-6 space-y-4">
         <h1 className="text-2xl font-bold">Human Resources</h1>

--- a/next_frontend_web/src/pages/hr/leave.tsx
+++ b/next_frontend_web/src/pages/hr/leave.tsx
@@ -3,7 +3,7 @@ import RoleGuard from '../../components/Auth/RoleGuard';
 import LeaveCalendar from '../../components/ERP/HR/LeaveCalendar';
 
 const LeavePage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager', 'employee']}>
+  <RoleGuard roles={['Admin', 'HR']}>
     <MainLayout>
       <LeaveCalendar />
     </MainLayout>

--- a/next_frontend_web/src/pages/hr/payroll.tsx
+++ b/next_frontend_web/src/pages/hr/payroll.tsx
@@ -3,7 +3,7 @@ import RoleGuard from '../../components/Auth/RoleGuard';
 import SalaryProcessing from '../../components/ERP/HR/SalaryProcessing';
 
 const PayrollPage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager', 'employee']}>
+  <RoleGuard roles={['Admin', 'HR']}>
     <MainLayout>
       <SalaryProcessing />
     </MainLayout>

--- a/next_frontend_web/src/pages/login.tsx
+++ b/next_frontend_web/src/pages/login.tsx
@@ -4,15 +4,15 @@ import { useAuth } from '../context/AuthContext';
 import { LoginPage } from '../components/Auth/LoginPage';
 
 const Login: React.FC = () => {
-  const { state } = useAuth();
+  const { state, hasRole } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
     if (state.isAuthenticated) {
-      const target = state.user?.role === 'admin' ? '/dashboard' : '/sales';
+      const target = hasRole('Admin') ? '/dashboard' : '/sales';
       router.replace(target);
     }
-  }, [state.isAuthenticated, state.user, router]);
+  }, [state.isAuthenticated, hasRole, router]);
 
   return <LoginPage />;
 };

--- a/next_frontend_web/src/pages/register.tsx
+++ b/next_frontend_web/src/pages/register.tsx
@@ -4,15 +4,15 @@ import { useAuth } from '../context/AuthContext';
 import { RegisterPage } from '../components/Auth/RegisterPage';
 
 const Register: React.FC = () => {
-  const { state } = useAuth();
+  const { state, hasRole } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
     if (state.isAuthenticated) {
-      const target = state.user?.role === 'admin' ? '/dashboard' : '/sales';
+      const target = hasRole('Admin') ? '/dashboard' : '/sales';
       router.replace(target);
     }
-  }, [state.isAuthenticated, state.user, router]);
+  }, [state.isAuthenticated, hasRole, router]);
 
   return <RegisterPage />;
 };

--- a/next_frontend_web/src/pages/sales/history.tsx
+++ b/next_frontend_web/src/pages/sales/history.tsx
@@ -3,7 +3,7 @@ import SalesHistory from '../../components/ERP/Sales/SalesHistory';
 import RoleGuard from '../../components/Auth/RoleGuard';
 
 const SalesHistoryPage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager']}>
+  <RoleGuard roles={['Admin', 'Manager', 'Sales']}>
     <MainLayout>
       <SalesHistory />
     </MainLayout>

--- a/next_frontend_web/src/pages/sales/index.tsx
+++ b/next_frontend_web/src/pages/sales/index.tsx
@@ -3,7 +3,7 @@ import SalesInterface from '../../components/ERP/Sales/SalesInterface';
 import RoleGuard from '../../components/Auth/RoleGuard';
 
 const SalesPage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager']}>
+  <RoleGuard roles={['Admin', 'Manager', 'Sales']}>
     <MainLayout>
       <SalesInterface />
     </MainLayout>

--- a/next_frontend_web/src/pages/sales/invoice.tsx
+++ b/next_frontend_web/src/pages/sales/invoice.tsx
@@ -3,7 +3,7 @@ import InvoiceView from '../../components/ERP/Sales/InvoiceView';
 import RoleGuard from '../../components/Auth/RoleGuard';
 
 const InvoicePage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager']}>
+  <RoleGuard roles={['Admin', 'Manager', 'Sales']}>
     <MainLayout>
       <InvoiceView />
     </MainLayout>

--- a/next_frontend_web/src/pages/sales/quick.tsx
+++ b/next_frontend_web/src/pages/sales/quick.tsx
@@ -3,7 +3,7 @@ import ClassicPOS from '../../components/ERP/Sales/ClassicPOS';
 import RoleGuard from '../../components/Auth/RoleGuard';
 
 const QuickSalesPage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager']}>
+  <RoleGuard roles={['Admin', 'Manager', 'Sales']}>
     <MainLayout>
       <ClassicPOS />
     </MainLayout>

--- a/next_frontend_web/src/pages/sales/returns.tsx
+++ b/next_frontend_web/src/pages/sales/returns.tsx
@@ -3,7 +3,7 @@ import ModernPOS from '../../components/ERP/Sales/ModernPOS';
 import RoleGuard from '../../components/Auth/RoleGuard';
 
 const ReturnsPage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager']}>
+  <RoleGuard roles={['Admin', 'Manager', 'Sales']}>
     <MainLayout>
       <ModernPOS mode="return" />
     </MainLayout>

--- a/next_frontend_web/src/types/index.ts
+++ b/next_frontend_web/src/types/index.ts
@@ -3,7 +3,7 @@ export interface User {
   username: string;
   email: string;
   fullName: string;
-  role: 'admin' | 'manager' | 'user';
+  role: 'Admin' | 'Manager' | 'Sales' | 'HR' | 'Accountant' | 'Store' | 'User';
   companyId: string;
   isActive: boolean;
   permissions: string[];


### PR DESCRIPTION
## Summary
- expose user role and permissions in `useAuth`
- restrict Sales module to Sales/Manager/Admin and HR module to HR/Admin
- show HR section in sidebar only for HR/Admin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a5ef325ab0832cb9d289481f631b48