### PR TITLE
Add help dropdown links

### DIFF
--- a/next_frontend_web/src/components/Layout/Header.tsx
+++ b/next_frontend_web/src/components/Layout/Header.tsx
@@ -239,16 +239,16 @@ const Header: React.FC = () => {
             {showHelpDropdown && (
               <div className="absolute right-0 mt-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50 min-w-[8rem]">
                 <a
-                  href="/help"
+                  href="/faq"
                   className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
                 >
-                  User Guide
+                  FAQ
                 </a>
                 <a
                   href="/support"
                   className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
                 >
-                  Support
+                  Contact Support
                 </a>
               </div>
             )}

--- a/next_frontend_web/src/pages/faq.tsx
+++ b/next_frontend_web/src/pages/faq.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+const FAQPage: React.FC = () => (
+  <div className="max-w-3xl mx-auto p-6">
+    <h1 className="text-2xl font-bold mb-4">Frequently Asked Questions</h1>
+    <div className="space-y-4">
+      <div>
+        <h2 className="font-semibold">How do I contact support?</h2>
+        <p>You can reach out through the contact form available on the support page.</p>
+      </div>
+      <div>
+        <h2 className="font-semibold">Where can I learn more about the application?</h2>
+        <p>Check the documentation and guides provided in the help section.</p>
+      </div>
+    </div>
+  </div>
+);
+
+export default FAQPage;

--- a/next_frontend_web/src/pages/support.tsx
+++ b/next_frontend_web/src/pages/support.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+
+const SupportPage: React.FC = () => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitted(true);
+  };
+
+  return (
+    <div className="max-w-xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">Contact Support</h1>
+      {submitted ? (
+        <p className="text-green-600">Your message has been sent!</p>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block mb-1">Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full border rounded p-2"
+              required
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Email</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full border rounded p-2"
+              required
+            />
+          </div>
+          <div>
+            <label className="block mb-1">Message</label>
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              className="w-full border rounded p-2"
+              rows={4}
+              required
+            />
+          </div>
+          <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">Send</button>
+        </form>
+      )}
+    </div>
+  );
+};
+
+export default SupportPage;


### PR DESCRIPTION
## Summary
- add FAQ and support pages
- link header help menu to FAQ and contact support pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f14c9ee0832c912c69f696e349a2