### PR TITLE
Add company creation service and page integration

### DIFF
--- a/next_frontend_web/src/components/Auth/CompanyCreatePage.tsx
+++ b/next_frontend_web/src/components/Auth/CompanyCreatePage.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from 'react';
 import { Building, Save } from 'lucide-react';
+import { useRouter } from 'next/router';
+import { companies } from '../../services';
 
 const CompanyCreatePage: React.FC = () => {
   const [form, setForm] = useState({ name: '', address: '', phone: '', email: '' });
+  const router = useRouter();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -11,7 +14,13 @@ const CompanyCreatePage: React.FC = () => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: integrate with company creation service
+    try {
+      await companies.createCompany(form);
+      router.push('/settings/company');
+    } catch (error: any) {
+      console.error('Error creating company:', error);
+      alert(error.message || 'Failed to create company');
+    }
   };
 
   return (

--- a/next_frontend_web/src/services/companies.ts
+++ b/next_frontend_web/src/services/companies.ts
@@ -1,0 +1,5 @@
+import api from './apiClient';
+import { Company } from '../types';
+
+export const createCompany = (payload: Partial<Company>) =>
+  api.post<Company>('/api/v1/companies', payload);

--- a/next_frontend_web/src/services/index.ts
+++ b/next_frontend_web/src/services/index.ts
@@ -3,6 +3,7 @@ export * as auth from './auth';
 export * as products from './products';
 export * as categories from './categories';
 export * as customers from './customers';
+export * as companies from './companies';
 export * as sales from './sales';
 export * as dashboard from './dashboard';
 export * as inventory from './inventory';


### PR DESCRIPTION
## Summary
- hook CompanyCreatePage form up to new company creation API service
- add companies API wrapper for POST `/api/v1/companies`
- expose companies service in service index

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a601934c28832c80bb04c8c3cca710