### PR TITLE
feat: add password reset support

### DIFF
--- a/next_frontend_web/src/components/Auth/PasswordResetPage.tsx
+++ b/next_frontend_web/src/components/Auth/PasswordResetPage.tsx
@@ -1,18 +1,48 @@
 import React, { useState } from 'react';
-import { Mail, Send } from 'lucide-react';
+import { Mail, Send, AlertCircle, CheckCircle } from 'lucide-react';
+import { forgotPassword } from '../../services/auth';
 
 const PasswordResetPage: React.FC = () => {
   const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // TODO: integrate with password reset service
+    setStatus(null);
+    setLoading(true);
+    try {
+      const res = await forgotPassword(email);
+      setStatus({ type: 'success', message: res.message || 'Reset link sent' });
+    } catch (err: any) {
+      setStatus({ type: 'error', message: err.message || 'Failed to send reset link' });
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-red-50 to-red-100 dark:from-gray-900 dark:to-gray-800 flex items-center justify-center p-4">
       <div className="w-full max-w-md bg-white dark:bg-gray-900 rounded-2xl shadow-xl p-8 border border-gray-200 dark:border-gray-700">
         <h1 className="text-2xl font-bold text-gray-800 dark:text-white mb-6 text-center">Reset Password</h1>
+
+        {status && (
+          <div
+            className={`mb-6 p-4 border rounded-lg flex items-center space-x-3 text-sm ${
+              status.type === 'success'
+                ? 'bg-green-50 border-green-200 text-green-700 dark:bg-green-900/30 dark:border-green-800 dark:text-green-300'
+                : 'bg-red-50 border-red-200 text-red-700 dark:bg-red-900/30 dark:border-red-800 dark:text-red-300'
+            }`}
+          >
+            {status.type === 'success' ? (
+              <CheckCircle className="w-5 h-5" />
+            ) : (
+              <AlertCircle className="w-5 h-5" />
+            )}
+            <span>{status.message}</span>
+          </div>
+        )}
+
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
             <label htmlFor="email" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
@@ -36,10 +66,17 @@ const PasswordResetPage: React.FC = () => {
           </div>
           <button
             type="submit"
-            className="w-full flex justify-center items-center py-3 px-4 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+            disabled={loading}
+            className="w-full flex justify-center items-center py-3 px-4 border border-transparent rounded-lg shadow-sm text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <Send className="w-5 h-5 mr-2" />
-            Send Reset Link
+            {loading ? (
+              <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
+            ) : (
+              <>
+                <Send className="w-5 h-5 mr-2" />
+                Send Reset Link
+              </>
+            )}
           </button>
         </form>
       </div>

--- a/next_frontend_web/src/services/auth.ts
+++ b/next_frontend_web/src/services/auth.ts
@@ -41,3 +41,17 @@ export const logout = async () => {
   clearAuthTokens();
 };
 
+export const forgotPassword = (email: string) =>
+  api.post<{ message: string }>(
+    '/api/v1/auth/forgot-password',
+    { email },
+    { auth: false }
+  );
+
+export const resetPassword = (token: string, newPassword: string) =>
+  api.post<{ message: string }>(
+    '/api/v1/auth/reset-password',
+    { token, newPassword },
+    { auth: false }
+  );
+


### PR DESCRIPTION
## Summary
- implement password reset service helpers
- wire password reset page to request reset links and show feedback

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)
- `npm install --no-audit --no-fund` (fails: 403 Forbidden - GET https://registry.npmjs.org/@typescript-eslint%2feslint-plugin)


------
https://chatgpt.com/codex/tasks/task_e_68a60355877c832ca54c018ed62a47a3