### PR TITLE
Use env-based API proxy URL and document env vars

### DIFF
--- a/next_frontend_web/README.md
+++ b/next_frontend_web/README.md
@@ -1,0 +1,11 @@
+# Next Frontend Web
+
+## Environment Variables
+
+The application requires the following environment variables to be set:
+
+- `NEXT_PUBLIC_API_URL` – Base URL used by the client for API requests.
+- `API_PROXY_URL` – URL used by Next.js rewrites to proxy `/api/*` calls to the backend.
+
+Define these variables in your environment or in a `.env` file before running or building the project.
+

--- a/next_frontend_web/next.config.js
+++ b/next_frontend_web/next.config.js
@@ -15,7 +15,7 @@ const nextConfig = {
     return [
       {
         source: '/api/:path*',
-        destination: 'http://localhost:8080/api/:path*',
+        destination: `${process.env.API_PROXY_URL}/api/:path*`,
       },
     ];
   },


### PR DESCRIPTION
## Summary
- refactor Next.js rewrite destination to use `process.env.API_PROXY_URL`
- document `NEXT_PUBLIC_API_URL` and `API_PROXY_URL` in frontend README

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a606a3ed3c832cb9888f3ebb385ad6