### PR TITLE
chore: isolate offline-only utilities for desktop mode

### DIFF
--- a/next_frontend_web/electron/utils/DatabaseStatus.tsx
+++ b/next_frontend_web/electron/utils/DatabaseStatus.tsx
@@ -1,3 +1,4 @@
+// NOTE: Reserved for future desktop offline mode. Not used in web builds.
 import React, { useState, useEffect } from 'react';
 import { Database, Wifi, WifiOff, CheckCircle, XCircle, RefreshCw, Play } from 'lucide-react';
 

--- a/next_frontend_web/electron/utils/README.md
+++ b/next_frontend_web/electron/utils/README.md
@@ -1,0 +1,4 @@
+# Electron Utilities
+
+These utilities are reserved for the upcoming **desktop offline mode** and are not meant to be imported by web-facing code.
+

--- a/next_frontend_web/electron/utils/dataInitializer.ts
+++ b/next_frontend_web/electron/utils/dataInitializer.ts
@@ -1,3 +1,4 @@
+// NOTE: Reserved for future desktop offline mode. Not used in web builds.
 export class DataInitializer {
   async checkAndInitializeSampleData(): Promise<void> {
     console.log('Sample data initialization is disabled.');


### PR DESCRIPTION
## Summary
- relocate DatabaseStatus and DataInitializer into `electron/utils`
- document these helpers for future desktop offline mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6047ff15c832c8dc2f45c23aa660c