### PR TITLE
Ensure API calls use selected company and location

### DIFF
--- a/next_frontend_web/src/pages/login.tsx
+++ b/next_frontend_web/src/pages/login.tsx
@@ -1,18 +1,25 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useAuth } from '../context/AuthContext';
+import { useAppActions } from '../context/MainContext';
 import { LoginPage } from '../components/Auth/LoginPage';
 
 const Login: React.FC = () => {
   const { state, hasRole } = useAuth();
+  const { setCurrentCompany, setCurrentLocation } = useAppActions();
   const router = useRouter();
 
   useEffect(() => {
-    if (state.isAuthenticated) {
+    if (state.isAuthenticated && state.company) {
+      setCurrentCompany(state.company._id);
+      const defaultLocation = state.company.locations?.[0]?._id;
+      if (defaultLocation) {
+        setCurrentLocation(defaultLocation);
+      }
       const target = hasRole('Admin') ? '/dashboard' : '/sales';
       router.replace(target);
     }
-  }, [state.isAuthenticated, hasRole, router]);
+  }, [state.isAuthenticated, state.company, hasRole, router, setCurrentCompany, setCurrentLocation]);
 
   return <LoginPage />;
 };


### PR DESCRIPTION
## Summary
- Initialize app's company and location from authenticated user
- Load data only when company and location are set
- Set company/location after login and include headers on API requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a60e6f94ac832cb693b61baca1f41d