### PR TITLE
feat: add API proxy URL and fallback

### DIFF
--- a/next_frontend_web/.env.local
+++ b/next_frontend_web/.env.local
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_API_URL=http://localhost:8080/api/v1
+API_PROXY_URL=http://localhost:8080
 NEXT_PUBLIC_AUTH_REDIRECT=http://localhost:3000/auth/callback

--- a/next_frontend_web/README.md
+++ b/next_frontend_web/README.md
@@ -5,7 +5,12 @@
 The application requires the following environment variables to be set:
 
 - `NEXT_PUBLIC_API_URL` – Base URL used by the client for API requests.
-- `API_PROXY_URL` – URL used by Next.js rewrites to proxy `/api/*` calls to the backend.
+- `API_PROXY_URL` – URL used by Next.js rewrites to proxy `/api/*` calls to the backend. Defaults to `NEXT_PUBLIC_API_URL` if not set.
 
-Define these variables in your environment or in a `.env` file before running or building the project.
+Define these variables in your environment or in a `.env` file before running or building the project. For example:
 
+```
+NEXT_PUBLIC_API_URL=http://localhost:8080/api/v1
+API_PROXY_URL=http://localhost:8080
+NEXT_PUBLIC_AUTH_REDIRECT=http://localhost:3000/auth/callback
+```

--- a/next_frontend_web/next.config.js
+++ b/next_frontend_web/next.config.js
@@ -12,10 +12,11 @@ const nextConfig = {
   basePath: '',
   distDir: 'out',
   async rewrites() {
+    const apiProxyUrl = process.env.API_PROXY_URL || process.env.NEXT_PUBLIC_API_URL;
     return [
       {
         source: '/api/:path*',
-        destination: `${process.env.API_PROXY_URL}/api/:path*`,
+        destination: `${apiProxyUrl}/api/:path*`,
       },
     ];
   },


### PR DESCRIPTION
## Summary
- document API_PROXY_URL and sample configuration
- add API_PROXY_URL to environment config
- default API proxy to NEXT_PUBLIC_API_URL when not provided

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a60f11a290832c91de85da3c1aa88f