### PR TITLE
Switch to server rendering for i18n

### DIFF
--- a/next_frontend_web/README.md
+++ b/next_frontend_web/README.md
@@ -14,3 +14,7 @@ NEXT_PUBLIC_API_URL=http://localhost:8080/api/v1
 API_PROXY_URL=http://localhost:8080
 NEXT_PUBLIC_AUTH_REDIRECT=http://localhost:3000/auth/callback
 ```
+
+## Deployment
+
+This project runs with server-side rendering due to its use of internationalization. To create a production build, run `npm run build` and then launch the application with `npm start`. Ensure the environment variables above are configured in your hosting environment.

--- a/next_frontend_web/next.config.js
+++ b/next_frontend_web/next.config.js
@@ -3,13 +3,9 @@ const { i18n } = require('./next-i18next.config');
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   i18n,
-  output: 'export',
-  trailingSlash: true,
   images: {
     unoptimized: true,
   },
-  assetPrefix: process.env.NODE_ENV === 'production' ? './' : '',
-  basePath: '',
   distDir: 'out',
   async rewrites() {
     const apiProxyUrl = process.env.API_PROXY_URL || process.env.NEXT_PUBLIC_API_URL;


### PR DESCRIPTION
## Summary
- remove static export and trailing slash so Next.js can run with i18n and rewrites
- document server-side deployment process and required env vars

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals")*
- `API_PROXY_URL=http://localhost:8080 npm run build` *(fails: Property 'locations' does not exist on type 'AppState')*

------
https://chatgpt.com/codex/tasks/task_e_68a73d5958c4832c8dc9144610bb7057