### PR TITLE
Remove client-side credentials and document runtime config

### DIFF
--- a/next_frontend_web/README.md
+++ b/next_frontend_web/README.md
@@ -21,6 +21,7 @@ The application requires the following environment variables to be set:
 - `NEXT_PUBLIC_API_URL` – Base URL used by the client for API requests.
 - `API_PROXY_URL` – URL used by Next.js rewrites to proxy `/api/*` calls to the backend. Defaults to `NEXT_PUBLIC_API_URL` if not set.
 - `NEXT_PUBLIC_AUTH_REDIRECT` – Redirect URL for authentication callbacks.
+- `COUCHDB_URL` – CouchDB endpoint. Only the URL is exposed to the browser through Next.js runtime configuration; credentials must be provided server-side.
 
 Define these variables in your environment or in a `.env` file before running or building the project. For example:
 
@@ -28,12 +29,17 @@ Define these variables in your environment or in a `.env` file before running or
 NEXT_PUBLIC_API_URL=http://localhost:8080/api/v1
 API_PROXY_URL=http://localhost:8080
 NEXT_PUBLIC_AUTH_REDIRECT=http://localhost:3000/auth/callback
+COUCHDB_URL=http://localhost:5984
 ```
+
+### Runtime overrides
+
+Non-sensitive values such as `COUCHDB_URL` can be overridden in the browser by adding `<meta>` tags with names prefixed by `env:` or by setting the `pos_env_overrides` entry in `localStorage`. These mechanisms are intended for development and should not include secrets.
 
 ## Deployment
 
 This project runs with server-side rendering due to its use of internationalization. To create a production build, run `npm run build` and then launch the application with `npm start`. Ensure the environment variables above are configured in your hosting environment.
-=======
+
 ## Development Server
 
 Start the application in watch mode:

--- a/next_frontend_web/next.config.js
+++ b/next_frontend_web/next.config.js
@@ -13,6 +13,9 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  publicRuntimeConfig: {
+    COUCHDB_URL: process.env.COUCHDB_URL,
+  },
   async rewrites() {
     const apiProxyUrl = process.env.API_PROXY_URL || process.env.NEXT_PUBLIC_API_URL;
     return [

--- a/next_frontend_web/public/env.js
+++ b/next_frontend_web/public/env.js
@@ -1,17 +1,6 @@
 (function() {
-  // Default environment variables
-  const defaults = {
-    NEXT_PUBLIC_COUCHDB_URL: 'http://localhost:5984',
-    NEXT_PUBLIC_COUCHDB_USERNAME: 'admin', 
-    NEXT_PUBLIC_COUCHDB_PASSWORD: 'admin',
-    NODE_ENV: 'production'
-  };
-
   // Initialize window.ENV
   window.ENV = window.ENV || {};
-
-  // Apply defaults first
-  Object.assign(window.ENV, defaults);
 
   // Override with meta tags if present
   document.querySelectorAll('meta[name^="env:"]').forEach(meta => {
@@ -34,8 +23,5 @@
     }
   }
 
-  console.log('Environment initialized:', {
-    ...window.ENV,
-    NEXT_PUBLIC_COUCHDB_PASSWORD: '***'
-  });
+  console.log('Environment initialized:', window.ENV);
 })();

--- a/next_frontend_web/src/types/global.d.ts
+++ b/next_frontend_web/src/types/global.d.ts
@@ -2,8 +2,6 @@ declare global {
   interface Window {
     ENV: {
       NEXT_PUBLIC_COUCHDB_URL?: string;
-      NEXT_PUBLIC_COUCHDB_USERNAME?: string;
-      NEXT_PUBLIC_COUCHDB_PASSWORD?: string;
       NODE_ENV?: string;
     };
     testDatabaseConnection?: () => Promise<any>;


### PR DESCRIPTION
## Summary
- drop hardcoded CouchDB defaults from client `env.js`
- expose `COUCHDB_URL` via Next.js runtime config
- document runtime overrides and required env vars

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: numerous lint errors such as `@typescript-eslint/no-explicit-any`)*

------
https://chatgpt.com/codex/tasks/task_e_68a74876bee4832c87959a234ac12f06