### PR TITLE
chore: add explicit dashboard and sidebar types

### DIFF
--- a/next_frontend_web/src/components/ERP/Dashboard.tsx
+++ b/next_frontend_web/src/components/ERP/Dashboard.tsx
@@ -15,19 +15,7 @@ import {
   CreditCard
 } from 'lucide-react';
 import QuickActionMenu from './Common/QuickActionMenu';
-
-interface DashboardStats {
-  todayRevenue: number;
-  todayOrders: number;
-  totalCustomers: number;
-  lowStockCount: number;
-  recentSales: any[];
-  topProducts: any[];
-  lowStockProducts: any[];
-  totalProducts: number;
-  totalInventoryValue: number;
-  creditOutstanding: number;
-}
+import { DashboardStats, Product, Sale } from '../../types';
 
 const Dashboard: React.FC = () => {
   const state = useAppState(s => s);
@@ -162,9 +150,9 @@ const Dashboard: React.FC = () => {
     );
   
     // Calculate top products (simplified)
-    const productSales = new Map();
-    state.recentSales.forEach(sale => {
-      sale.items.forEach((item: any) => {
+    const productSales = new Map<string, { name: string; quantity: number; revenue: number }>();
+    state.recentSales.forEach((sale: Sale) => {
+      sale.items.forEach((item) => {
         const current = productSales.get(item.productId) || { name: item.productName, quantity: 0, revenue: 0 };
         current.quantity += item.quantity;
         current.revenue += item.totalPrice;
@@ -206,7 +194,7 @@ const Dashboard: React.FC = () => {
     });
   };
 
-  const getStockStatusColor = (product: any) => {
+  const getStockStatusColor = (product: Product) => {
     if (product.stock === 0) return 'text-red-600 dark:text-red-400';
     if (product.stock <= (product.minStock || 5)) return 'text-yellow-600 dark:text-yellow-400';
     return 'text-green-600 dark:text-green-400';

--- a/next_frontend_web/src/components/Layout/Sidebar.tsx
+++ b/next_frontend_web/src/components/Layout/Sidebar.tsx
@@ -30,11 +30,12 @@ import {
   Blocks,
   Printer,
 } from 'lucide-react';
+import { SidebarView, Product } from '../../types';
 
 interface MenuItem {
   icon?: React.ElementType;
   label: string;
-  view?: string;
+  view?: SidebarView;
   subItems?: MenuItem[];
   badge?: number;
   roles?: string[];
@@ -46,7 +47,7 @@ const Sidebar: React.FC = () => {
   const [expandedItems, setExpandedItems] = useState<string[]>(['Sales']);
 
   const lowStockCount = state.products.filter(
-    (p) => typeof p.minStock === 'number' && p.stock <= p.minStock!
+    (p: Product) => typeof p.minStock === 'number' && p.stock <= p.minStock!
   ).length;
 
   const menuItems: MenuItem[] = [
@@ -166,11 +167,11 @@ const Sidebar: React.FC = () => {
     );
   };
 
-  const handleItemClick = (view: string) => {
-    dispatch({ type: 'SET_VIEW', payload: view as any });
+  const handleItemClick = (view: SidebarView) => {
+    dispatch({ type: 'SET_VIEW', payload: view });
   };
 
-  const isActive = (view: string) => state.currentView === view;
+  const isActive = (view: SidebarView) => state.currentView === view;
 
   const isItemActive = (item: MenuItem): boolean => {
     if (item.view && isActive(item.view)) return true;

--- a/next_frontend_web/src/components/MainApp.tsx
+++ b/next_frontend_web/src/components/MainApp.tsx
@@ -8,6 +8,7 @@ import ProductManagement from './ERP/Inventory/ProductManagement';
 import CustomerManagement from './ERP/Customers/CustomerManagement';
 import ErrorBoundary from './Misc/ErrorBoundary';
 import { MapPin } from 'lucide-react';
+import { Location } from '../types';
 
 const MainApp: React.FC = () => {
   const { state } = useApp();
@@ -78,7 +79,7 @@ const MainApp: React.FC = () => {
             Please select a location to continue
           </p>
           <div className="space-y-2">
-            {authState.company.locations.map((location) => (
+            {authState.company.locations.map((location: Location) => (
               <button
                 key={location._id}
                 // onClick={() => {

--- a/next_frontend_web/src/types/index.ts
+++ b/next_frontend_web/src/types/index.ts
@@ -195,9 +195,50 @@ export interface Supplier extends AuditFields {
   notes?: string;
 }
 
+export type SidebarView =
+  | 'dashboard'
+  | 'sales'
+  | 'sales-invoice'
+  | 'sales-returns'
+  | 'sales-history'
+  | 'collectionss'
+  | 'customers'
+  | 'customers_management'
+  | 'purchase-entry'
+  | 'purchase-orders'
+  | 'purchase-returns'
+  | 'suppliers'
+  | 'inventory'
+  | 'inventory-products'
+  | 'inventory-stock-transfers'
+  | 'inventory-low-stock'
+  | 'inventory-suppliers'
+  | 'cash-register'
+  | 'vouchers'
+  | 'ledgers'
+  | 'banking'
+  | 'sales-reports'
+  | 'inventory-reports'
+  | 'customer-reports'
+  | 'supplier-reports'
+  | 'purchase-reports'
+  | 'accounts-reports'
+  | 'general-reports'
+  | 'employees'
+  | 'attendance'
+  | 'payroll'
+  | 'leave-management'
+  | 'settings-general'
+  | 'settings-company'
+  | 'settings-users'
+  | 'settings-devices'
+  | 'settings-backup'
+  | 'settings-integrations'
+  | 'settings-pos-printer';
+
 export interface AppState {
   // UI State
-  currentView: 'dashboard' | 'sales' | 'inventory' | 'customers' | 'reports' | 'settings';
+  currentView: SidebarView;
   selectedCategory: string;
   isLoading: boolean;
   isInitialized: boolean;
@@ -398,7 +439,7 @@ type AppAction =
   | { type: 'SET_LOADING'; payload: boolean }
   | { type: 'SET_INITIALIZED'; payload: boolean }
   | { type: 'SET_ERROR'; payload: string | null }
-  | { type: 'SET_VIEW'; payload: AppState['currentView'] }
+  | { type: 'SET_VIEW'; payload: SidebarView }
   | { type: 'SET_CATEGORY'; payload: string }
   | { type: 'SET_PRODUCTS'; payload: Product[] }
   | { type: 'ADD_PRODUCT'; payload: Product }

--- a/next_frontend_web/tsconfig.json
+++ b/next_frontend_web/tsconfig.json
@@ -4,6 +4,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "noImplicitAny": true,
     "noEmit": true,
     "incremental": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- add `SidebarView` union and use it for view navigation
- type dashboard stats collections and related helpers
- enable `noImplicitAny` and address new type errors

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Failed to load config "next/core-web-vitals" to extend from.)

------
https://chatgpt.com/codex/tasks/task_e_68a7488427f8832c9d191a841bbe85b8