### PR TITLE
chore: remove CouchDB config and references

### DIFF
--- a/next_frontend_web/README.md
+++ b/next_frontend_web/README.md
@@ -21,7 +21,6 @@ The application requires the following environment variables to be set:
 - `NEXT_PUBLIC_API_URL` – Base URL used by the client for API requests.
 - `API_PROXY_URL` – URL used by Next.js rewrites to proxy `/api/*` calls to the backend. Defaults to `NEXT_PUBLIC_API_URL` if not set.
 - `NEXT_PUBLIC_AUTH_REDIRECT` – Redirect URL for authentication callbacks.
-- `COUCHDB_URL` – CouchDB endpoint. Only the URL is exposed to the browser through Next.js runtime configuration; credentials must be provided server-side.
 
 Define these variables in your environment or in a `.env` file before running or building the project. For example:
 
@@ -29,12 +28,7 @@ Define these variables in your environment or in a `.env` file before running or
 NEXT_PUBLIC_API_URL=http://localhost:8080/api/v1
 API_PROXY_URL=http://localhost:8080
 NEXT_PUBLIC_AUTH_REDIRECT=http://localhost:3000/auth/callback
-COUCHDB_URL=http://localhost:5984
 ```
-
-### Runtime overrides
-
-Non-sensitive values such as `COUCHDB_URL` can be overridden in the browser by adding `<meta>` tags with names prefixed by `env:` or by setting the `pos_env_overrides` entry in `localStorage`. These mechanisms are intended for development and should not include secrets.
 
 ## Deployment
 

--- a/next_frontend_web/next.config.js
+++ b/next_frontend_web/next.config.js
@@ -13,9 +13,6 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
-  publicRuntimeConfig: {
-    COUCHDB_URL: process.env.COUCHDB_URL,
-  },
   async rewrites() {
     const apiProxyUrl = process.env.API_PROXY_URL || process.env.NEXT_PUBLIC_API_URL;
     return [

--- a/next_frontend_web/src/types/global.d.ts
+++ b/next_frontend_web/src/types/global.d.ts
@@ -1,7 +1,7 @@
 declare global {
   interface Window {
     ENV: {
-      NEXT_PUBLIC_COUCHDB_URL?: string;
+      NEXT_PUBLIC_API_URL?: string;
       NODE_ENV?: string;
     };
     testDatabaseConnection?: () => Promise<any>;


### PR DESCRIPTION
## Summary
- remove unused CouchDB runtime config
- replace deprecated env var with NEXT_PUBLIC_API_URL type
- clean README to show only API environment variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: see errors in output)*

------
https://chatgpt.com/codex/tasks/task_e_68a751946b78832cb620f4cd3d89b8ff