### PR TITLE
feat: add typed purchase and accounting payloads

### DIFF
--- a/next_frontend_web/src/components/ERP/Accounting/LedgerView.tsx
+++ b/next_frontend_web/src/components/ERP/Accounting/LedgerView.tsx
@@ -1,12 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { accounting } from '../../../services';
-import { LedgerEntry } from '../../../types/accounting';
-
-interface AccountBalance {
-  accountId: number;
-  accountName: string;
-  balance: number;
-}
+import { LedgerEntry, AccountBalance } from '../../../types/accounting';
 
 const LedgerView: React.FC = () => {
   const [balances, setBalances] = useState<AccountBalance[]>([]);
@@ -18,7 +12,7 @@ const LedgerView: React.FC = () => {
 
   const loadEntries = (accountId: number) => {
     accounting
-      .getLedgerEntries(accountId)
+      .getLedgerEntries({ accountId })
       .then((data) => setEntries(data));
   };
 

--- a/next_frontend_web/src/components/ERP/Common/QuickActionMenu.tsx
+++ b/next_frontend_web/src/components/ERP/Common/QuickActionMenu.tsx
@@ -63,7 +63,7 @@ const QuickActionMenu: React.FC = () => {
         <QuickActionButton
           icon={<ShoppingBag className="w-5 h-5 text-white" />}
           label="Purchase"
-          onClick={() => dispatch({ type: 'SET_VIEW', payload: 'purchase-entry' as any })}
+          onClick={() => dispatch({ type: 'SET_VIEW', payload: 'purchase-entry' })}
           color="bg-gradient-to-r from-blue-500 to-blue-600"
           position={1}
           isVisible={isOpen}
@@ -72,7 +72,7 @@ const QuickActionMenu: React.FC = () => {
         <QuickActionButton
           icon={<Banknote className="w-5 h-5 text-white" />}
           label="Collection"
-          onClick={() => dispatch({ type: 'SET_VIEW', payload: 'collectionss' as any })}
+          onClick={() => dispatch({ type: 'SET_VIEW', payload: 'collectionss' })}
           color="bg-gradient-to-r from-green-500 to-green-600"
           position={2}
           isVisible={isOpen}
@@ -81,7 +81,7 @@ const QuickActionMenu: React.FC = () => {
         <QuickActionButton
           icon={<CreditCard className="w-5 h-5 text-white" />}
           label="Expense"
-          onClick={() => dispatch({ type: 'SET_VIEW', payload: 'cash-register' as any })}
+          onClick={() => dispatch({ type: 'SET_VIEW', payload: 'cash-register' })}
           color="bg-gradient-to-r from-purple-500 to-purple-600"
           position={3}
           isVisible={isOpen}

--- a/next_frontend_web/src/services/accounting.ts
+++ b/next_frontend_web/src/services/accounting.ts
@@ -1,5 +1,12 @@
 import api from './apiClient';
-import { CashRegister, Voucher, LedgerEntry } from '../types/accounting';
+import {
+  CashRegister,
+  Voucher,
+  VoucherPayload,
+  LedgerEntry,
+  LedgerQueryPayload,
+  AccountBalance,
+} from '../types/accounting';
 
 // Cash Register
 export const getCashRegisters = () =>
@@ -21,13 +28,13 @@ export const recordCashTally = (payload: { count: number; notes?: string }) =>
 export const listVouchers = () =>
   api.get<Voucher[]>('/api/v1/vouchers');
 
-export const createVoucher = (type: string, payload: any) =>
+export const createVoucher = (type: string, payload: VoucherPayload) =>
   api.post<{ voucherId: number }>(`/api/v1/vouchers/${type}`, payload);
 
 // Ledger
 export const getLedgerBalances = () =>
-  api.get<any[]>('/api/v1/ledgers');
+  api.get<AccountBalance[]>('/api/v1/ledgers');
 
 export const getLedgerEntries = (
-  accountId: number | string
-) => api.get<LedgerEntry[]>(`/api/v1/ledgers/${accountId}/entries`);
+  payload: LedgerQueryPayload
+) => api.get<LedgerEntry[]>(`/api/v1/ledgers/${payload.accountId}/entries`);

--- a/next_frontend_web/src/services/purchases.ts
+++ b/next_frontend_web/src/services/purchases.ts
@@ -1,8 +1,18 @@
 import api from './apiClient';
+import {
+  PurchaseOrderPayload,
+  PurchaseOrder,
+  GoodsReceiptPayload,
+  GoodsReceipt,
+  PurchaseReturnPayload,
+  PurchaseReturn,
+} from '../types/purchases';
 
-export const createPurchaseOrder = (payload: any) =>
-  api.post('/api/v1/purchase-orders', payload);
-export const recordGoodsReceipt = (payload: any) =>
-  api.post('/api/v1/goods-receipts', payload);
-export const createPurchaseReturn = (payload: any) =>
-  api.post('/api/v1/purchase-returns', payload);
+export const createPurchaseOrder = (payload: PurchaseOrderPayload) =>
+  api.post<PurchaseOrder>('/api/v1/purchase-orders', payload);
+
+export const recordGoodsReceipt = (payload: GoodsReceiptPayload) =>
+  api.post<GoodsReceipt>('/api/v1/goods-receipts', payload);
+
+export const createPurchaseReturn = (payload: PurchaseReturnPayload) =>
+  api.post<PurchaseReturn>('/api/v1/purchase-returns', payload);

--- a/next_frontend_web/src/types/accounting.ts
+++ b/next_frontend_web/src/types/accounting.ts
@@ -14,6 +14,11 @@ export interface Voucher {
   createdAt: string;
 }
 
+export interface VoucherPayload {
+  amount: number;
+  description?: string;
+}
+
 export interface LedgerEntry {
   id: number;
   accountId: number;
@@ -22,4 +27,16 @@ export interface LedgerEntry {
   credit: number;
   balance: number;
   entryDate: string;
+}
+
+export interface LedgerQueryPayload {
+  accountId: number | string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+export interface AccountBalance {
+  accountId: number;
+  accountName: string;
+  balance: number;
 }

--- a/next_frontend_web/src/types/purchases.ts
+++ b/next_frontend_web/src/types/purchases.ts
@@ -1,0 +1,55 @@
+export interface PurchaseOrderItemPayload {
+  productId: number;
+  quantity: number;
+  unitPrice: number;
+}
+
+export interface PurchaseOrderPayload {
+  supplierId: number | string;
+  referenceNumber?: string;
+  items: PurchaseOrderItemPayload[];
+}
+
+export interface PurchaseOrder {
+  purchaseOrderId: number;
+  supplierId: number;
+  referenceNumber?: string;
+  status: string;
+  totalAmount: number;
+  items: PurchaseOrderItemPayload[];
+}
+
+export interface GoodsReceiptItemPayload {
+  productId: number;
+  quantity: number;
+}
+
+export interface GoodsReceiptPayload {
+  purchaseId: number | string;
+  items: GoodsReceiptItemPayload[];
+}
+
+export interface GoodsReceipt {
+  goodsReceiptId: number;
+  purchaseId: number;
+  items: GoodsReceiptItemPayload[];
+}
+
+export interface PurchaseReturnItemPayload {
+  productId: number;
+  quantity: number;
+  unitPrice: number;
+}
+
+export interface PurchaseReturnPayload {
+  purchaseId: number | string;
+  reason?: string;
+  items: PurchaseReturnItemPayload[];
+}
+
+export interface PurchaseReturn {
+  returnId: number;
+  purchaseId: number;
+  reason?: string;
+  items: PurchaseReturnItemPayload[];
+}


### PR DESCRIPTION
## Summary
- remove unsafe casts from quick action menu
- add typed payloads and responses for purchases and accounting
- wire ledger view and services to new accounting types

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from.)*


------
https://chatgpt.com/codex/tasks/task_e_68a758ec1010832c8e1e4c4063e2751a