### PR TITLE
chore: guard env initialization log

### DIFF
--- a/next_frontend_web/public/env.js
+++ b/next_frontend_web/public/env.js
@@ -11,8 +11,12 @@
     }
   });
 
+  const isDev =
+    window.location.hostname === 'localhost' ||
+    window.location.hostname === '127.0.0.1';
+
   // Development overrides from localStorage
-  if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+  if (isDev) {
     try {
       const overrides = localStorage.getItem('pos_env_overrides');
       if (overrides) {
@@ -23,5 +27,7 @@
     }
   }
 
-  console.log('Environment initialized:', window.ENV);
+  if (isDev) {
+    console.log('Environment initialized:', window.ENV);
+  }
 })();


### PR DESCRIPTION
## Summary
- only log environment initialization during local development in env.js

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Failed to load config "next/core-web-vitals")

------
https://chatgpt.com/codex/tasks/task_e_68a75a44c848832ca228b19cd61baf74