### PR TITLE
docs: note manual testing in README

### DIFF
--- a/next_frontend_web/README.md
+++ b/next_frontend_web/README.md
@@ -67,12 +67,12 @@ npm run electron-pack
 
 This command runs `next build` and then packages the app using `electron-builder`.
 
-## Testing and Linting
+## Linting and Manual Testing
 
-The continuous integration pipeline runs tests and linting using these commands:
+Automated tests are not currently configured. Verify changes by running the
+application and exercising its features manually in your environment.
 
 ```bash
-npm test      # run unit tests
 npm run lint  # run ESLint
 ```
 


### PR DESCRIPTION
## Summary
- document that the project relies on manual testing
- keep lint instructions in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a75ae34098832ca2d90a95f9fccc8f