### PR TITLE
Allow custom company and location headers in CORS

### DIFF
--- a/go_backend_rmt/internal/config/config.go
+++ b/go_backend_rmt/internal/config/config.go
@@ -70,7 +70,7 @@ func Load() *Config {
 		// CORS
 		AllowedOrigins: []string{getEnv("ALLOWED_ORIGINS", "http://localhost:3000")},
 		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders: []string{"Content-Type", "Authorization"},
+		AllowedHeaders: []string{"Content-Type", "Authorization", "Accept", "company_id", "location_id"},
 
 		// Rate Limiting
 		RateLimitRequests: parseInt("RATE_LIMIT_REQUESTS", 100),

--- a/go_backend_rmt/internal/middleware/cors.go
+++ b/go_backend_rmt/internal/middleware/cors.go
@@ -11,15 +11,11 @@ import (
 
 // CORS middleware handles Cross-Origin Resource Sharing
 func CORS(cfg *config.Config) gin.HandlerFunc {
-	allowedOrigins := strings.Join(cfg.AllowedOrigins, ", ")
-	allowedMethods := strings.Join(cfg.AllowedMethods, ", ")
-	allowedHeaders := strings.Join(cfg.AllowedHeaders, ", ")
-
 	return func(c *gin.Context) {
 		// Add CORS headers
-		c.Header("Access-Control-Allow-Origin", allowedOrigins)
-		c.Header("Access-Control-Allow-Methods", allowedMethods)
-		c.Header("Access-Control-Allow-Headers", allowedHeaders)
+		c.Header("Access-Control-Allow-Origin", strings.Join(cfg.AllowedOrigins, ", "))
+		c.Header("Access-Control-Allow-Methods", strings.Join(cfg.AllowedMethods, ", "))
+		c.Header("Access-Control-Allow-Headers", strings.Join(cfg.AllowedHeaders, ", "))
 		c.Header("Access-Control-Expose-Headers", "Content-Length, X-Total-Count")
 		c.Header("Access-Control-Allow-Credentials", "true")
 		c.Header("Access-Control-Max-Age", "86400")


### PR DESCRIPTION
## Summary
- allow `company_id` and `location_id` headers in config
- expose updated allowed headers in CORS middleware

## Testing
- `go test ./...` *(fails: command hung)*
- `go build ./cmd/server`
- `./server` *(fails: failed to connect to database: dial tcp [::1]:5432: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a767d8c6c4832c885ed2984f1a3759