### PR TITLE
Handle specific CORS origins

### DIFF
--- a/go_backend_rmt/internal/config/config.go
+++ b/go_backend_rmt/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -68,7 +69,7 @@ func Load() *Config {
 		Environment: getEnv("ENVIRONMENT", "development"),
 
 		// CORS
-		AllowedOrigins: []string{getEnv("ALLOWED_ORIGINS", "http://localhost:3000")},
+		AllowedOrigins: parseCSV("ALLOWED_ORIGINS", "http://localhost:3000"),
 		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowedHeaders: []string{"Content-Type", "Authorization", "Accept", "company_id", "location_id"},
 
@@ -137,4 +138,16 @@ func parseSize(key, defaultValue string) int64 {
 		}
 	}
 	return 10 * 1024 * 1024 // 10MB default
+}
+
+func parseCSV(key, defaultValue string) []string {
+	value := getEnv(key, defaultValue)
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }

--- a/go_backend_rmt/internal/middleware/cors.go
+++ b/go_backend_rmt/internal/middleware/cors.go
@@ -12,8 +12,24 @@ import (
 // CORS middleware handles Cross-Origin Resource Sharing
 func CORS(cfg *config.Config) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Add CORS headers
-		c.Header("Access-Control-Allow-Origin", strings.Join(cfg.AllowedOrigins, ", "))
+		origin := c.Request.Header.Get("Origin")
+		allowed := false
+		for _, o := range cfg.AllowedOrigins {
+			if o == origin {
+				allowed = true
+				break
+			}
+		}
+
+		if origin != "" && !allowed {
+			c.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+
+		if allowed {
+			c.Header("Access-Control-Allow-Origin", origin)
+		}
+
 		c.Header("Access-Control-Allow-Methods", strings.Join(cfg.AllowedMethods, ", "))
 		c.Header("Access-Control-Allow-Headers", strings.Join(cfg.AllowedHeaders, ", "))
 		c.Header("Access-Control-Expose-Headers", "Content-Length, X-Total-Count")


### PR DESCRIPTION
## Summary
- validate request origins against configured allowlist
- allow comma-separated `ALLOWED_ORIGINS` env values

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a76915da5c832cbfcf5462c75ef6ff