### PR TITLE
Conditionally set secure flag for cookies in development

### DIFF
--- a/next_frontend_web/src/services/apiClient.ts
+++ b/next_frontend_web/src/services/apiClient.ts
@@ -14,7 +14,9 @@ const getCookie = (name: string): string | null => {
 const setCookie = (name: string, value: string, days = 7) => {
   if (typeof document === 'undefined') return;
   const expires = new Date(Date.now() + days * 864e5).toUTCString();
-  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/; secure; SameSite=Strict`;
+  const isSecure =
+    typeof window !== 'undefined' && window.location.protocol === 'https:';
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/; SameSite=Strict${isSecure ? '; secure' : ''}`;
 };
 
 const deleteCookie = (name: string) => {


### PR DESCRIPTION
## Summary
- Conditionally apply the `secure` cookie flag only when running over HTTPS
- Allow local development over HTTP to store auth tokens without weakening production security

## Testing
- `npm test --prefix next_frontend_web` (fails: Missing script "test")
- `npm run lint --prefix next_frontend_web`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68a76a4336e0832cba58af41a5c76384