### PR TITLE
Return updated entities from update endpoints

### DIFF
--- a/go_backend_rmt/internal/handlers/customer.go
+++ b/go_backend_rmt/internal/handlers/customer.go
@@ -138,7 +138,8 @@ func (h *CustomerHandler) UpdateCustomer(c *gin.Context) {
 		return
 	}
 
-	if err := h.customerService.UpdateCustomer(customerID, companyID, userID, &req); err != nil {
+	customer, err := h.customerService.UpdateCustomer(customerID, companyID, userID, &req)
+	if err != nil {
 		if err.Error() == "customer not found" {
 			utils.NotFoundResponse(c, "Customer not found")
 			return
@@ -147,7 +148,7 @@ func (h *CustomerHandler) UpdateCustomer(c *gin.Context) {
 		return
 	}
 
-	utils.SuccessResponse(c, "Customer updated successfully", nil)
+	utils.SuccessResponse(c, "Customer updated successfully", customer)
 }
 
 // DELETE /customers/:id

--- a/go_backend_rmt/internal/handlers/product.go
+++ b/go_backend_rmt/internal/handlers/product.go
@@ -142,7 +142,7 @@ func (h *ProductHandler) UpdateProduct(c *gin.Context) {
 		return
 	}
 
-	err = h.productService.UpdateProduct(productID, companyID, userID, &req)
+	product, err := h.productService.UpdateProduct(productID, companyID, userID, &req)
 	if err != nil {
 		if err.Error() == "product not found" {
 			utils.NotFoundResponse(c, "Product not found")
@@ -156,7 +156,7 @@ func (h *ProductHandler) UpdateProduct(c *gin.Context) {
 		return
 	}
 
-	utils.SuccessResponse(c, "Product updated successfully", nil)
+	utils.SuccessResponse(c, "Product updated successfully", product)
 }
 
 // DELETE /products/:id

--- a/go_backend_rmt/internal/handlers/supplier.go
+++ b/go_backend_rmt/internal/handlers/supplier.go
@@ -161,7 +161,7 @@ func (h *SupplierHandler) UpdateSupplier(c *gin.Context) {
 		return
 	}
 
-	err = h.supplierService.UpdateSupplier(supplierID, companyID, userID, &req)
+	supplier, err := h.supplierService.UpdateSupplier(supplierID, companyID, userID, &req)
 	if err != nil {
 		if err.Error() == "supplier not found" {
 			utils.NotFoundResponse(c, "Supplier not found")
@@ -175,7 +175,7 @@ func (h *SupplierHandler) UpdateSupplier(c *gin.Context) {
 		return
 	}
 
-	utils.SuccessResponse(c, "Supplier updated successfully", nil)
+	utils.SuccessResponse(c, "Supplier updated successfully", supplier)
 }
 
 // DELETE /suppliers/:id

--- a/go_backend_rmt/internal/services/product_service_barcode_test.go
+++ b/go_backend_rmt/internal/services/product_service_barcode_test.go
@@ -33,12 +33,12 @@ func TestUpdateProduct_InvalidPrimaryBarcode(t *testing.T) {
 			{Barcode: "222"},
 		},
 	}
-	if err := svc.UpdateProduct(1, 1, 1, req); err == nil {
+	if _, err := svc.UpdateProduct(1, 1, 1, req); err == nil {
 		t.Fatalf("expected error for missing primary barcode")
 	}
 	req.Barcodes[0].IsPrimary = true
 	req.Barcodes[1].IsPrimary = true
-	if err := svc.UpdateProduct(1, 1, 1, req); err == nil {
+	if _, err := svc.UpdateProduct(1, 1, 1, req); err == nil {
 		t.Fatalf("expected error for multiple primary barcodes")
 	}
 }

--- a/next_frontend_web/src/services/customers.ts
+++ b/next_frontend_web/src/services/customers.ts
@@ -1,11 +1,13 @@
 import api from "./apiClient";
-import { Customer, CreditTransaction } from "../types";
+import { Customer, CreditTransaction, ApiResponse } from "../types";
 
 export const getCustomers = () => api.get<Customer[]>("/api/v1/customers");
 export const createCustomer = (payload: Partial<Customer>) =>
   api.post<Customer>("/api/v1/customers", payload);
 export const updateCustomer = (id: string, payload: Partial<Customer>) =>
-  api.put<Customer>(`/api/v1/customers/${id}`, payload);
+  api
+    .put<ApiResponse<Customer>>(`/api/v1/customers/${id}`, payload)
+    .then((res) => res.data!);
 export const deleteCustomer = (id: string) =>
   api.delete<void>(`/api/v1/customers/${id}`);
 export const updateCustomerCredit = (

--- a/next_frontend_web/src/services/products.ts
+++ b/next_frontend_web/src/services/products.ts
@@ -1,11 +1,15 @@
-import api from './apiClient';
-import { Product } from '../types';
+import api from "./apiClient";
+import { Product, ApiResponse } from "../types";
 
-export const getProducts = (query = '') =>
+export const getProducts = (query = "") =>
   api.get<Product[]>(`/api/v1/products${query}`);
-export const getProduct = (id: string) => api.get<Product>(`/api/v1/products/${id}`);
+export const getProduct = (id: string) =>
+  api.get<Product>(`/api/v1/products/${id}`);
 export const createProduct = (payload: Partial<Product>) =>
-  api.post<Product>('/api/v1/products', payload);
+  api.post<Product>("/api/v1/products", payload);
 export const updateProduct = (id: string, payload: Partial<Product>) =>
-  api.put<Product>(`/api/v1/products/${id}`, payload);
-export const deleteProduct = (id: string) => api.delete<void>(`/api/v1/products/${id}`);
+  api
+    .put<ApiResponse<Product>>(`/api/v1/products/${id}`, payload)
+    .then((res) => res.data!);
+export const deleteProduct = (id: string) =>
+  api.delete<void>(`/api/v1/products/${id}`);

--- a/next_frontend_web/src/services/suppliers.ts
+++ b/next_frontend_web/src/services/suppliers.ts
@@ -1,11 +1,13 @@
-import api from './apiClient';
-import { Supplier } from '../types';
+import api from "./apiClient";
+import { Supplier, ApiResponse } from "../types";
 
-export const getSuppliers = () => api.get<Supplier[]>('/api/v1/suppliers');
+export const getSuppliers = () => api.get<Supplier[]>("/api/v1/suppliers");
 export const createSupplier = (payload: Partial<Supplier>) =>
-  api.post<Supplier>('/api/v1/suppliers', payload);
+  api.post<Supplier>("/api/v1/suppliers", payload);
 export const updateSupplier = (id: string, payload: Partial<Supplier>) =>
-  api.put<Supplier>(`/api/v1/suppliers/${id}`, payload);
+  api
+    .put<ApiResponse<Supplier>>(`/api/v1/suppliers/${id}`, payload)
+    .then((res) => res.data!);
 export const deleteSupplier = (id: string) =>
   api.delete<void>(`/api/v1/suppliers/${id}`);
 export const searchSuppliers = (query: string) =>


### PR DESCRIPTION
## Summary
- Return updated product/customer/supplier from update handlers
- Fetch updated records in product, customer, and supplier services
- Frontend update services now use returned entity in state updates

## Testing
- `go test ./...`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a85d55efc0832cb69c72679bbe694b