### PR TITLE
Standardize credit balance field name

### DIFF
--- a/go_backend_rmt/Docs & Schema/PostgrSQL.sql
+++ b/go_backend_rmt/Docs & Schema/PostgrSQL.sql
@@ -1948,7 +1948,7 @@ SELECT
     COALESCE(SUM(p.total_amount), 0) AS total_purchases,
     COALESCE(SUM(pay.amount), 0) AS total_payments,
     COALESCE(SUM(pr.total_amount), 0) AS total_returns,
-    COALESCE(SUM(p.total_amount), 0) - COALESCE(SUM(pay.amount), 0) - COALESCE(SUM(pr.total_amount), 0) AS outstanding_balance
+    COALESCE(SUM(p.total_amount), 0) - COALESCE(SUM(pay.amount), 0) - COALESCE(SUM(pr.total_amount), 0) AS credit_balance
 FROM suppliers s
 LEFT JOIN purchases p ON p.supplier_id = s.supplier_id AND p.is_deleted = FALSE
 LEFT JOIN payments pay ON pay.supplier_id = s.supplier_id AND pay.is_deleted = FALSE

--- a/go_backend_rmt/internal/models/customer.go
+++ b/go_backend_rmt/internal/models/customer.go
@@ -1,20 +1,20 @@
 package models
 
 type Customer struct {
-	CustomerID         int                        `json:"customer_id" db:"customer_id"`
-	CompanyID          int                        `json:"company_id" db:"company_id"`
-	Name               string                     `json:"name" db:"name" validate:"required,min=2,max=255"`
-	Phone              *string                    `json:"phone,omitempty" db:"phone"`
-	Email              *string                    `json:"email,omitempty" db:"email" validate:"omitempty,email"`
-	Address            *string                    `json:"address,omitempty" db:"address"`
-	TaxNumber          *string                    `json:"tax_number,omitempty" db:"tax_number"`
-	CreditLimit        float64                    `json:"credit_limit" db:"credit_limit"`
-	PaymentTerms       int                        `json:"payment_terms" db:"payment_terms"` // Days
-	IsActive           bool                       `json:"is_active" db:"is_active"`
-	CreatedBy          int                        `json:"created_by" db:"created_by"`
-	UpdatedBy          *int                       `json:"updated_by,omitempty" db:"updated_by"`
-	OutstandingBalance float64                    `json:"outstanding_balance,omitempty" db:"-"`
-	Invoices           []CustomerInvoiceReference `json:"invoices,omitempty" db:"-"`
+	CustomerID    int                        `json:"customer_id" db:"customer_id"`
+	CompanyID     int                        `json:"company_id" db:"company_id"`
+	Name          string                     `json:"name" db:"name" validate:"required,min=2,max=255"`
+	Phone         *string                    `json:"phone,omitempty" db:"phone"`
+	Email         *string                    `json:"email,omitempty" db:"email" validate:"omitempty,email"`
+	Address       *string                    `json:"address,omitempty" db:"address"`
+	TaxNumber     *string                    `json:"tax_number,omitempty" db:"tax_number"`
+	CreditLimit   float64                    `json:"credit_limit" db:"credit_limit"`
+	PaymentTerms  int                        `json:"payment_terms" db:"payment_terms"` // Days
+	IsActive      bool                       `json:"is_active" db:"is_active"`
+	CreatedBy     int                        `json:"created_by" db:"created_by"`
+	UpdatedBy     *int                       `json:"updated_by,omitempty" db:"updated_by"`
+	CreditBalance float64                    `json:"credit_balance,omitempty" db:"-"`
+	Invoices      []CustomerInvoiceReference `json:"invoices,omitempty" db:"-"`
 	SyncModel
 }
 

--- a/go_backend_rmt/internal/services/collection_service.go
+++ b/go_backend_rmt/internal/services/collection_service.go
@@ -231,7 +231,7 @@ func (s *CollectionService) GetCollectionByID(collectionID, companyID int) (*mod
 func (s *CollectionService) GetOutstanding(companyID int) ([]models.Customer, error) {
 	query := `
                SELECT c.customer_id, c.name,
-                      COALESCE(SUM(s.total_amount - s.paid_amount),0) AS outstanding_balance
+                      COALESCE(SUM(s.total_amount - s.paid_amount),0) AS credit_balance
                FROM customers c
                JOIN sales s ON c.customer_id = s.customer_id
                WHERE c.company_id = $1 AND c.is_deleted = FALSE AND s.is_deleted = FALSE
@@ -248,7 +248,7 @@ func (s *CollectionService) GetOutstanding(companyID int) ([]models.Customer, er
 	var customers []models.Customer
 	for rows.Next() {
 		var cust models.Customer
-		if err := rows.Scan(&cust.CustomerID, &cust.Name, &cust.OutstandingBalance); err != nil {
+		if err := rows.Scan(&cust.CustomerID, &cust.Name, &cust.CreditBalance); err != nil {
 			return nil, fmt.Errorf("failed to scan customer: %w", err)
 		}
 

--- a/go_backend_rmt/internal/services/customer_service.go
+++ b/go_backend_rmt/internal/services/customer_service.go
@@ -25,7 +25,7 @@ func (s *CustomerService) GetCustomers(companyID int, filters map[string]string)
                 SELECT c.customer_id, c.company_id, c.name, c.phone, c.email, c.address, c.tax_number,
                        c.credit_limit, c.payment_terms, c.is_active, c.created_by, c.updated_by,
                        c.sync_status, c.created_at, c.updated_at, c.is_deleted,
-                       COALESCE(SUM(s.total_amount - s.paid_amount),0) AS outstanding_balance
+                       COALESCE(SUM(s.total_amount - s.paid_amount),0) AS credit_balance
                 FROM customers c
                 LEFT JOIN sales s ON c.customer_id = s.customer_id AND s.is_deleted = FALSE
                 WHERE c.company_id = $1 AND c.is_deleted = FALSE`
@@ -107,7 +107,7 @@ func (s *CustomerService) GetCustomers(companyID int, filters map[string]string)
 			&c.CustomerID, &c.CompanyID, &c.Name, &c.Phone, &c.Email, &c.Address,
 			&c.TaxNumber, &c.CreditLimit, &c.PaymentTerms, &c.IsActive,
 			&c.CreatedBy, &c.UpdatedBy, &c.SyncStatus, &c.CreatedAt, &c.UpdatedAt, &c.IsDeleted,
-			&c.OutstandingBalance,
+			&c.CreditBalance,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan customer: %w", err)
 		}

--- a/next_frontend_web/src/components/ERP/Customers/CollectionEntryModal.tsx
+++ b/next_frontend_web/src/components/ERP/Customers/CollectionEntryModal.tsx
@@ -35,8 +35,8 @@ const CollectionEntryModal: React.FC<Props> = ({ customer, onSubmit, onClose }) 
           <div className="grid grid-cols-2 gap-4 text-sm">
             <div>
               <span className="text-gray-600 dark:text-gray-400">Current Balance:</span>
-              <div className={`${customer.creditBalance > 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'} font-medium`}>
-                {formatCurrency(customer.creditBalance)}
+              <div className={`${customer.credit_balance > 0 ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'} font-medium`}>
+                {formatCurrency(customer.credit_balance)}
               </div>
             </div>
             <div>

--- a/next_frontend_web/src/components/ERP/Customers/CustomerList.tsx
+++ b/next_frontend_web/src/components/ERP/Customers/CustomerList.tsx
@@ -120,12 +120,12 @@ const CustomerList: React.FC<CustomerListProps> = ({
               <td className="px-6 py-4 whitespace-nowrap">
                 <div
                   className={`text-sm font-medium ${
-                    customer.creditBalance > 0
+                    customer.credit_balance > 0
                       ? 'text-red-600 dark:text-red-400'
                       : 'text-green-600 dark:text-green-400'
                   }`}
                 >
-                  {formatCurrency(customer.creditBalance)}
+                  {formatCurrency(customer.credit_balance)}
                 </div>
               </td>
               <td className="px-6 py-4 whitespace-nowrap">

--- a/next_frontend_web/src/components/ERP/Customers/CustomerManagement.tsx
+++ b/next_frontend_web/src/components/ERP/Customers/CustomerManagement.tsx
@@ -70,7 +70,7 @@ const CustomerManagement: React.FC = () => {
     e.preventDefault();
     await createCustomer({
       ...formData,
-      creditBalance: 0,
+      credit_balance: 0,
       loyaltyPoints: 0,
       isActive: true
     });
@@ -149,7 +149,7 @@ const CustomerManagement: React.FC = () => {
           locationId: state.currentLocationId || '',
           creditLimit: Number(row.creditLimit) || 0,
           notes: row.notes || '',
-          creditBalance: 0,
+          credit_balance: 0,
           loyaltyPoints: 0,
           isActive: true
         });

--- a/next_frontend_web/src/components/ERP/Customers/CustomerSummaryModal.tsx
+++ b/next_frontend_web/src/components/ERP/Customers/CustomerSummaryModal.tsx
@@ -49,7 +49,7 @@ const CustomerSummaryModal: React.FC<Props> = ({ customer, onClose }) => {
           </div>
           <div className="flex items-center text-gray-700 dark:text-gray-300">
             <Wallet className="w-4 h-4 mr-2" />
-            Balance: {formatCurrency(customer.creditBalance)}
+            Balance: {formatCurrency(customer.credit_balance)}
           </div>
         </div>
       </div>

--- a/next_frontend_web/src/components/ERP/Dashboard.tsx
+++ b/next_frontend_web/src/components/ERP/Dashboard.tsx
@@ -150,7 +150,7 @@ const Dashboard: React.FC = () => {
   
     // Calculate credit outstanding
     const creditOutstanding = state.customers.reduce((sum, c) => 
-      sum + c.creditBalance, 0
+      sum + c.credit_balance, 0
     );
   
     // Calculate top products (simplified)

--- a/next_frontend_web/src/components/ERP/Reports/CustomersReport.tsx
+++ b/next_frontend_web/src/components/ERP/Reports/CustomersReport.tsx
@@ -9,7 +9,7 @@ const CustomersReport: React.FC = () => (
     columns={[
       { key: 'name', label: 'Name' },
       { key: 'email', label: 'Email' },
-      { key: 'creditBalance', label: 'Credit' }
+      { key: 'credit_balance', label: 'Credit' }
     ]}
     dateField="createdAt"
   />

--- a/next_frontend_web/src/components/ERP/Sales/Cart.tsx
+++ b/next_frontend_web/src/components/ERP/Sales/Cart.tsx
@@ -40,7 +40,7 @@ const CustomerAddDialog: React.FC<{
     name: initialName,
     phone: '',
     address: '',
-    creditBalance: 0
+    credit_balance: 0
   });
 
   useEffect(() => {
@@ -50,7 +50,7 @@ const CustomerAddDialog: React.FC<{
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     onSave(formData);
-    setFormData({ name: '', phone: '', address: '', creditBalance: 0 });
+    setFormData({ name: '', phone: '', address: '', credit_balance: 0 });
     onClose();
   };
 
@@ -98,8 +98,8 @@ const CustomerAddDialog: React.FC<{
           </label>
           <input
             type="number"
-            value={formData.creditBalance}
-            onChange={(e) => setFormData({ ...formData, creditBalance: Number(e.target.value) })}
+            value={formData.credit_balance}
+            onChange={(e) => setFormData({ ...formData, credit_balance: Number(e.target.value) })}
             className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:border-red-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
             min="0"
           />
@@ -167,7 +167,7 @@ const Cart: React.FC = () => {
         _id: customer._id,
         phone: customer.phone,
         name: customer.name,
-        creditBalance: customer.creditBalance,
+        credit_balance: customer.credit_balance,
         address: customer.address
       } 
     });
@@ -201,7 +201,7 @@ const Cart: React.FC = () => {
   };
 
   const clearCustomer = () => {
-    dispatch({ type: 'SET_CUSTOMER', payload: { phone: '', name: '', creditBalance: 0, address: '' } });
+    dispatch({ type: 'SET_CUSTOMER', payload: { phone: '', name: '', credit_balance: 0, address: '' } });
     setCustomerSearch('');
   };
 
@@ -254,11 +254,11 @@ const Cart: React.FC = () => {
                       </div>
                       <div className="text-right">
                         <div className={`text-sm font-medium ${
-                          customer.creditBalance > 0 
+                          customer.credit_balance > 0 
                             ? 'text-green-600 dark:text-green-400' 
                             : 'text-gray-500 dark:text-gray-400'
                         }`}>
-                          Credit: ₹{customer.creditBalance.toLocaleString()}
+                          Credit: ₹{customer.credit_balance.toLocaleString()}
                         </div>
                         <div className="text-xs text-gray-400 dark:text-gray-500">
                           {customer.loyaltyPoints} points
@@ -297,11 +297,11 @@ const Cart: React.FC = () => {
                 </div>
                 <div className="text-right">
                   <div className={`text-sm font-medium ${
-                    (state.customer.creditBalance || 0) > 0 
+                    (state.customer.credit_balance || 0) > 0 
                       ? 'text-green-600 dark:text-green-400' 
                       : 'text-gray-500 dark:text-gray-400'
                   }`}>
-                    Credit: ₹{(state.customer.creditBalance || 0).toLocaleString()}
+                    Credit: ₹{(state.customer.credit_balance || 0).toLocaleString()}
                   </div>
                   <button 
                     onClick={clearCustomer}

--- a/next_frontend_web/src/components/ERP/Sales/POSBase.tsx
+++ b/next_frontend_web/src/components/ERP/Sales/POSBase.tsx
@@ -71,7 +71,7 @@ const POSBase: React.FC<POSBaseProps> = ({ variant, mode = 'sale' }) => {
       locationId: state.currentLocationId || '',
       creditLimit: 0,
       notes: '',
-      creditBalance: 0,
+      credit_balance: 0,
       loyaltyPoints: 0,
       isActive: true
     });

--- a/next_frontend_web/src/components/ERP/Sales/SalesInterface.tsx
+++ b/next_frontend_web/src/components/ERP/Sales/SalesInterface.tsx
@@ -117,7 +117,7 @@ const SalesInterface: React.FC = () => {
   };
 
   const clearCustomer = () => {
-    dispatch({ type: 'SET_CUSTOMER', payload: { name: '', phone: '', address: '', creditBalance: 0 } });
+    dispatch({ type: 'SET_CUSTOMER', payload: { name: '', phone: '', address: '', credit_balance: 0 } });
   };
 
   const getSubtotal = () => {
@@ -152,7 +152,7 @@ const SalesInterface: React.FC = () => {
     if (selectedPaymentMethod === 'credit') {
       if (!state.customer._id) return false;
       const total = getTotal();
-      const newBalance = (state.customer.creditBalance || 0) + total;
+      const newBalance = (state.customer.credit_balance || 0) + total;
       return newBalance <= (state.customer.creditLimit || 0);
     }
     return paymentReceived >= getTotal();
@@ -164,7 +164,7 @@ const SalesInterface: React.FC = () => {
     const newCustomer = await createCustomer({
         ...newCustomerForm,
         locationId: newCustomerForm.locationId || state.currentLocationId, // Use form or current location
-        creditBalance: 0,
+        credit_balance: 0,
         loyaltyPoints: 0,
         isActive: true
     });
@@ -361,9 +361,9 @@ const SalesInterface: React.FC = () => {
                     <div className="text-xs text-gray-500 dark:text-gray-400">
                       {state.customer.phone}
                     </div>
-                    {(state.customer.creditBalance || 0) > 0 && (
+                    {(state.customer.credit_balance || 0) > 0 && (
                       <div className="text-xs text-red-600 dark:text-red-400">
-                        Credit: {formatCurrency(state.customer.creditBalance || 0)}
+                        Credit: {formatCurrency(state.customer.credit_balance || 0)}
                       </div>
                     )}
                   </div>
@@ -527,9 +527,9 @@ const SalesInterface: React.FC = () => {
                         <div className="text-sm text-gray-500 dark:text-gray-400">
                           {customer.phone}
                         </div>
-                        {customer.creditBalance > 0 && (
+                        {customer.credit_balance > 0 && (
                           <div className="text-sm text-red-600 dark:text-red-400">
-                            Credit: {formatCurrency(customer.creditBalance)}
+                            Credit: {formatCurrency(customer.credit_balance)}
                           </div>
                         )}
                       </div>
@@ -771,10 +771,10 @@ const SalesInterface: React.FC = () => {
                 </div>
                 <div className="text-sm text-yellow-700 dark:text-yellow-400 space-y-1">
                   <div>Customer: {state.customer.name}</div>
-                  <div>Current Balance: {formatCurrency(state.customer.creditBalance || 0)}</div>
-                  <div>New Balance: {formatCurrency((state.customer.creditBalance || 0) + getTotal())}</div>
+                  <div>Current Balance: {formatCurrency(state.customer.credit_balance || 0)}</div>
+                  <div>New Balance: {formatCurrency((state.customer.credit_balance || 0) + getTotal())}</div>
                   <div>Credit Limit: {formatCurrency(state.customer.creditLimit || 0)}</div>
-                  {(state.customer.creditBalance || 0) + getTotal() > (state.customer.creditLimit || 0) && (
+                  {(state.customer.credit_balance || 0) + getTotal() > (state.customer.creditLimit || 0) && (
                     <div className="text-red-600 dark:text-red-400 font-medium">
                       ⚠️ Credit limit exceeded!
                     </div>
@@ -818,7 +818,7 @@ const SalesInterface: React.FC = () => {
                 {state.cart.length === 0 && 'Cart is empty'}
                 {selectedPaymentMethod === 'credit' && !state.customer._id && 'Please select a customer for credit sale'}
                 {selectedPaymentMethod === 'credit' && state.customer._id && 
-                  (state.customer.creditBalance || 0) + getTotal() > (state.customer.creditLimit || 0) && 
+                  (state.customer.credit_balance || 0) + getTotal() > (state.customer.creditLimit || 0) && 
                   'Credit limit exceeded'}
                 {selectedPaymentMethod !== 'credit' && paymentReceived < getTotal() && 'Insufficient payment received'}
               </div>

--- a/next_frontend_web/src/context/MainContext.tsx
+++ b/next_frontend_web/src/context/MainContext.tsx
@@ -15,7 +15,7 @@ const initialState: AppState = {
   currentCompanyId: null,
   currentLocationId: null,
   cart: [],
-  customer: { phone: '', name: '', creditBalance: 0, address: '' },
+  customer: { phone: '', name: '', credit_balance: 0, address: '' },
   products: [],
   categories: ['All'],
   customers: [],
@@ -96,7 +96,7 @@ const appReducer = (state: AppState, action: AppAction): AppState => {
         cart: state.cart.map(i => i.product._id === action.payload.id ? { ...i, quantity: action.payload.quantity, totalPrice: action.payload.quantity * i.unitPrice } : i)
       };
     case 'CLEAR_CART':
-      return { ...state, cart: [], customer: { phone: '', name: '', creditBalance: 0, address: '' } };
+      return { ...state, cart: [], customer: { phone: '', name: '', credit_balance: 0, address: '' } };
     case 'SET_CUSTOMER':
       return { ...state, customer: { ...state.customer, ...action.payload } };
     case 'SET_RECENT_SALES':

--- a/next_frontend_web/src/types/index.ts
+++ b/next_frontend_web/src/types/index.ts
@@ -128,7 +128,7 @@ export interface Customer extends AuditFields {
   phone: string;
   email?: string;
   address?: string;
-  creditBalance: number;
+  credit_balance: number;
   creditLimit: number;
   loyaltyPoints?: number;
   companyId: string;
@@ -253,7 +253,7 @@ export interface AppState {
     name: string;
     phone: string;
     address?: string;
-    creditBalance?: number;
+    credit_balance?: number;
     creditLimit?: number;
   };
   


### PR DESCRIPTION
## Summary
- rename customer balance field to `credit_balance` in Go models and service queries
- update SQL schema view to use `credit_balance`
- propagate `credit_balance` field name through frontend types, context, and components

## Testing
- `go test ./...` *(hangs, process aborted)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a89b662170832c9e8cf7121b545619