### PR TITLE
Add date range filtering to ledger entries retrieval

### DIFF
--- a/go_backend_rmt/README.md
+++ b/go_backend_rmt/README.md
@@ -13,6 +13,13 @@ Optional query parameters:
 - `credit_min` / `credit_max` – credit limit range
 - `balance_min` / `balance_max` – outstanding balance range
 
+### GET /api/v1/ledgers/:account_id/entries
+
+Optional query parameters:
+
+- `date_from` – filter entries on or after this date (YYYY-MM-DD)
+- `date_to` – filter entries on or before this date (YYYY-MM-DD)
+
 ## Product Attributes
 
 The API supports dynamic product attributes. First create attribute definitions:

--- a/next_frontend_web/src/services/accounting.ts
+++ b/next_frontend_web/src/services/accounting.ts
@@ -37,4 +37,12 @@ export const getLedgerBalances = () =>
 
 export const getLedgerEntries = (
   payload: LedgerQueryPayload
-) => api.get<LedgerEntry[]>(`/api/v1/ledgers/${payload.accountId}/entries`);
+) => {
+  const params = new URLSearchParams();
+  if (payload.dateFrom) params.append('date_from', payload.dateFrom);
+  if (payload.dateTo) params.append('date_to', payload.dateTo);
+  const query = params.toString();
+  return api.get<LedgerEntry[]>(
+    `/api/v1/ledgers/${payload.accountId}/entries${query ? `?${query}` : ''}`
+  );
+};


### PR DESCRIPTION
## Summary
- Support optional `date_from` and `date_to` filters in `getLedgerEntries` service
- Document ledger entries API date range parameters

## Testing
- `npm run lint`
- `go test ./...` *(fails: models.Customer has no field or method OutstandingBalance)*

------
https://chatgpt.com/codex/tasks/task_e_68a89d27a984832cae47fd6a4641bbfa