### PR TITLE
Wire service helpers into UI and remove unused function

### DIFF
--- a/next_frontend_web/src/components/ERP/Accounting/CashRegister.tsx
+++ b/next_frontend_web/src/components/ERP/Accounting/CashRegister.tsx
@@ -5,18 +5,70 @@ import { CashRegister } from '../../../types/accounting';
 const CashRegister: React.FC = () => {
   const [registers, setRegisters] = useState<CashRegister[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [openingBalance, setOpeningBalance] = useState(0);
+  const [closingBalance, setClosingBalance] = useState(0);
 
-  useEffect(() => {
+  const refresh = () => {
     accounting
       .getCashRegisters()
       .then((data) => setRegisters(data))
       .catch((err) => setError(err.message));
+  };
+
+  useEffect(() => {
+    refresh();
   }, []);
+
+  const handleOpen = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await accounting.openCashRegister({ openingBalance });
+      setOpeningBalance(0);
+      refresh();
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  const handleClose = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await accounting.closeCashRegister({ closingBalance });
+      setClosingBalance(0);
+      refresh();
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
 
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Cash Register</h1>
       {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={handleOpen} className="space-x-2 mb-4">
+        <input
+          type="number"
+          value={openingBalance}
+          onChange={(e) => setOpeningBalance(parseFloat(e.target.value))}
+          className="border px-2 py-1"
+          placeholder="Opening balance"
+        />
+        <button type="submit" className="bg-green-600 text-white px-3 py-1 rounded">
+          Open Register
+        </button>
+      </form>
+      <form onSubmit={handleClose} className="space-x-2 mb-4">
+        <input
+          type="number"
+          value={closingBalance}
+          onChange={(e) => setClosingBalance(parseFloat(e.target.value))}
+          className="border px-2 py-1"
+          placeholder="Closing balance"
+        />
+        <button type="submit" className="bg-yellow-600 text-white px-3 py-1 rounded">
+          Close Register
+        </button>
+      </form>
       <ul className="space-y-2">
         {registers.map((r) => (
           <li key={r.id} className="border p-2 rounded">

--- a/next_frontend_web/src/components/ERP/Accounting/VoucherEntry.tsx
+++ b/next_frontend_web/src/components/ERP/Accounting/VoucherEntry.tsx
@@ -1,11 +1,21 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { accounting } from '../../../services';
+import { Voucher } from '../../../types/accounting';
 
 const VoucherEntry: React.FC = () => {
   const [type, setType] = useState('payment');
   const [amount, setAmount] = useState(0);
   const [description, setDescription] = useState('');
   const [message, setMessage] = useState('');
+  const [vouchers, setVouchers] = useState<Voucher[]>([]);
+
+  const refresh = () => {
+    accounting.listVouchers().then(setVouchers).catch(() => {});
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -14,44 +24,61 @@ const VoucherEntry: React.FC = () => {
       setMessage('Voucher created');
       setAmount(0);
       setDescription('');
+      refresh();
     } catch (err: any) {
       setMessage(err.message);
     }
   };
 
   return (
-    <form onSubmit={submit} className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Voucher Entry</h1>
-      {message && <p>{message}</p>}
+    <div className="p-4 space-y-4">
+      <form onSubmit={submit} className="space-y-4">
+        <h1 className="text-2xl font-bold">Voucher Entry</h1>
+        {message && <p>{message}</p>}
+        <div>
+          <label className="block mb-1">Type</label>
+          <select value={type} onChange={(e) => setType(e.target.value)} className="border p-2">
+            <option value="payment">Payment</option>
+            <option value="receipt">Receipt</option>
+            <option value="journal">Journal</option>
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Amount</label>
+          <input
+            type="number"
+            value={amount}
+            onChange={(e) => setAmount(parseFloat(e.target.value))}
+            className="border p-2 w-full"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Description</label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className="border p-2 w-full"
+          />
+        </div>
+        <button type="submit" className="bg-red-600 text-white px-4 py-2 rounded">
+          Save Voucher
+        </button>
+      </form>
       <div>
-        <label className="block mb-1">Type</label>
-        <select value={type} onChange={(e) => setType(e.target.value)} className="border p-2">
-          <option value="payment">Payment</option>
-          <option value="receipt">Receipt</option>
-          <option value="journal">Journal</option>
-        </select>
+        <h2 className="text-xl font-bold mt-4">Existing Vouchers</h2>
+        <ul className="mt-2 space-y-2">
+          {vouchers.map((v) => (
+            <li key={v.id} className="border p-2 rounded">
+              <div>
+                {v.type} - {v.amount}
+              </div>
+              {v.description && <div>{v.description}</div>}
+              <div>{new Date(v.createdAt).toLocaleString()}</div>
+            </li>
+          ))}
+        </ul>
       </div>
-      <div>
-        <label className="block mb-1">Amount</label>
-        <input
-          type="number"
-          value={amount}
-          onChange={(e) => setAmount(parseFloat(e.target.value))}
-          className="border p-2 w-full"
-        />
-      </div>
-      <div>
-        <label className="block mb-1">Description</label>
-        <textarea
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          className="border p-2 w-full"
-        />
-      </div>
-      <button type="submit" className="bg-red-600 text-white px-4 py-2 rounded">
-        Save Voucher
-      </button>
-    </form>
+    </div>
   );
 };
 

--- a/next_frontend_web/src/components/ERP/Inventory/StockAdjustments.tsx
+++ b/next_frontend_web/src/components/ERP/Inventory/StockAdjustments.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAppState } from '../../../context/MainContext';
 import { inventory } from '../../../services';
 
@@ -8,6 +8,11 @@ const StockAdjustments: React.FC = () => {
   const [locationId, setLocationId] = useState(state.currentLocationId || '');
   const [quantity, setQuantity] = useState(0);
   const [reason, setReason] = useState('');
+  const [adjustments, setAdjustments] = useState<any[]>([]);
+
+  useEffect(() => {
+    inventory.getStockAdjustments().then(setAdjustments).catch(() => {});
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -16,6 +21,7 @@ const StockAdjustments: React.FC = () => {
       setProductId('');
       setQuantity(0);
       setReason('');
+      inventory.getStockAdjustments().then(setAdjustments).catch(() => {});
     } catch (err) {
       console.error(err);
     }
@@ -61,6 +67,16 @@ const StockAdjustments: React.FC = () => {
         </div>
         <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">Adjust</button>
       </form>
+      <ul className="mt-4 space-y-2">
+        {adjustments.map((a, idx) => (
+          <li key={idx} className="border p-2 rounded">
+            <div>Product: {a.productId}</div>
+            <div>Location: {a.locationId}</div>
+            <div>Quantity: {a.quantity}</div>
+            {a.reason && <div>Reason: {a.reason}</div>}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 };

--- a/next_frontend_web/src/components/ERP/Inventory/TransferRequest.tsx
+++ b/next_frontend_web/src/components/ERP/Inventory/TransferRequest.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAppState } from '../../../context/MainContext';
 import { inventory } from '../../../services';
 
@@ -8,6 +8,11 @@ const TransferRequest: React.FC = () => {
   const [toLocation, setToLocation] = useState('');
   const [productId, setProductId] = useState('');
   const [quantity, setQuantity] = useState(0);
+  const [transfers, setTransfers] = useState<any[]>([]);
+
+  useEffect(() => {
+    inventory.getTransfers().then(setTransfers).catch(() => {});
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -19,6 +24,7 @@ const TransferRequest: React.FC = () => {
       });
       setProductId('');
       setQuantity(0);
+      inventory.getTransfers().then(setTransfers).catch(() => {});
     } catch (err) {
       console.error(err);
     }
@@ -64,6 +70,19 @@ const TransferRequest: React.FC = () => {
         </div>
         <button className="px-4 py-2 bg-blue-600 text-white rounded" type="submit">Request Transfer</button>
       </form>
+      <ul className="mt-4 space-y-2">
+        {transfers.map((t, idx) => (
+          <li key={idx} className="border p-2 rounded">
+            <div>From: {t.fromLocationId}</div>
+            <div>To: {t.toLocationId}</div>
+            <div>
+              Items:{' '}
+              {t.items?.map((i: any) => `${i.productId} (${i.quantity})`).join(', ')}
+            </div>
+            {t.reference && <div>Ref: {t.reference}</div>}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 };

--- a/next_frontend_web/src/services/accounting.ts
+++ b/next_frontend_web/src/services/accounting.ts
@@ -21,9 +21,6 @@ export const openCashRegister = (payload: { openingBalance: number }) =>
 export const closeCashRegister = (payload: { closingBalance: number }) =>
   api.post<void>('/api/v1/cash-registers/close', payload);
 
-export const recordCashTally = (payload: { count: number; notes?: string }) =>
-  api.post<void>('/api/v1/cash-registers/tally', payload);
-
 // Vouchers
 export const listVouchers = () =>
   api.get<Voucher[]>('/api/v1/vouchers');


### PR DESCRIPTION
## Summary
- display stock adjustments and transfers using existing inventory service helpers
- allow opening and closing cash registers and list vouchers via accounting services
- remove unused cash tally service function

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a89e3c7218832c8c81998c5f876816