### PR TITLE
Use auth context for transfer source and notes field

### DIFF
--- a/next_frontend_web/src/components/ERP/Inventory/TransferRequest.tsx
+++ b/next_frontend_web/src/components/ERP/Inventory/TransferRequest.tsx
@@ -4,7 +4,6 @@ import { inventory } from '../../../services';
 
 const TransferRequest: React.FC = () => {
   const state = useAppState(s => s);
-  const [fromLocation, setFromLocation] = useState(state.currentLocationId || '');
   const [toLocation, setToLocation] = useState('');
   const [productId, setProductId] = useState('');
   const [quantity, setQuantity] = useState(0);
@@ -18,7 +17,6 @@ const TransferRequest: React.FC = () => {
     e.preventDefault();
     try {
       await inventory.createTransfer({
-        fromLocationId: fromLocation,
         toLocationId: toLocation,
         items: [{ productId, quantity }],
       });
@@ -36,11 +34,9 @@ const TransferRequest: React.FC = () => {
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label className="block text-sm mb-1">From Location</label>
-          <input
-            className="w-full border px-2 py-1"
-            value={fromLocation}
-            onChange={e => setFromLocation(e.target.value)}
-          />
+          <div className="w-full border px-2 py-1 bg-gray-100">
+            {state.currentLocationId || ''}
+          </div>
         </div>
         <div>
           <label className="block text-sm mb-1">To Location</label>
@@ -79,7 +75,7 @@ const TransferRequest: React.FC = () => {
               Items:{' '}
               {t.items?.map((i: any) => `${i.productId} (${i.quantity})`).join(', ')}
             </div>
-            {t.reference && <div>Ref: {t.reference}</div>}
+            {t.notes && <div>Notes: {t.notes}</div>}
           </li>
         ))}
       </ul>

--- a/next_frontend_web/src/services/inventory.ts
+++ b/next_frontend_web/src/services/inventory.ts
@@ -14,10 +14,9 @@ export const getStockAdjustments = () =>
   api.get(`/api/v1/inventory/stock-adjustments`);
 
 export const createTransfer = (payload: {
-  fromLocationId: string;
   toLocationId: string;
   items: Array<{ productId: string; quantity: number }>;
-  reference?: string;
+  notes?: string;
 }) => api.post('/api/v1/inventory/transfers', payload);
 
 export const getTransfers = () => api.get('/api/v1/inventory/transfers');


### PR DESCRIPTION
## Summary
- remove `fromLocationId` from inventory transfer payload and rely on auth context for source
- rename transfer `reference` field to `notes`
- keep transfer items limited to `productId` and `quantity`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8aacf8224832c9408c2523c13f33a