### PR TITLE
Add purchaseDetailId to purchase return payload and forms

### DIFF
--- a/next_frontend_web/src/components/ERP/Purchase/PurchaseReturnForm.tsx
+++ b/next_frontend_web/src/components/ERP/Purchase/PurchaseReturnForm.tsx
@@ -4,6 +4,7 @@ import { purchases } from '../../../services';
 const PurchaseReturnForm: React.FC = () => {
   const [form, setForm] = useState({
     purchaseId: '',
+    purchaseDetailId: '',
     productId: '',
     quantity: 1,
     reason: '',
@@ -18,13 +19,14 @@ const PurchaseReturnForm: React.FC = () => {
         reason: form.reason,
         items: [
           {
+            purchaseDetailId: Number(form.purchaseDetailId),
             productId: Number(form.productId),
             quantity: Number(form.quantity),
             unitPrice: Number(form.unitPrice),
           },
         ],
       });
-      setForm({ purchaseId: '', productId: '', quantity: 1, reason: '', unitPrice: 0 });
+      setForm({ purchaseId: '', purchaseDetailId: '', productId: '', quantity: 1, reason: '', unitPrice: 0 });
     } catch (err) {
       console.error(err);
     }
@@ -38,6 +40,13 @@ const PurchaseReturnForm: React.FC = () => {
         placeholder="Purchase ID"
         value={form.purchaseId}
         onChange={e => setForm({ ...form, purchaseId: e.target.value })}
+        required
+      />
+      <input
+        className="border p-2 w-full"
+        placeholder="Purchase Detail ID"
+        value={form.purchaseDetailId}
+        onChange={e => setForm({ ...form, purchaseDetailId: e.target.value })}
         required
       />
       <input

--- a/next_frontend_web/src/services/purchases.ts
+++ b/next_frontend_web/src/services/purchases.ts
@@ -14,5 +14,7 @@ export const createPurchaseOrder = (payload: PurchaseOrderPayload) =>
 export const recordGoodsReceipt = (payload: GoodsReceiptPayload) =>
   api.post<GoodsReceipt | null>('/api/v1/goods-receipts', payload);
 
-export const createPurchaseReturn = (payload: PurchaseReturnPayload) =>
-  api.post<PurchaseReturn>('/api/v1/purchase-returns', payload);
+export const createPurchaseReturn = (payload: PurchaseReturnPayload) => {
+  // payload items should include purchaseDetailId
+  return api.post<PurchaseReturn>('/api/v1/purchase-returns', payload);
+};

--- a/next_frontend_web/src/types/purchases.ts
+++ b/next_frontend_web/src/types/purchases.ts
@@ -36,6 +36,7 @@ export interface GoodsReceipt {
 }
 
 export interface PurchaseReturnItemPayload {
+  purchaseDetailId: number;
   productId: number;
   quantity: number;
   unitPrice: number;


### PR DESCRIPTION
## Summary
- extend purchase return item payload with purchaseDetailId
- include purchase detail ID in purchase return form submission
- document purchaseDetailId requirement in purchase return service

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `go test ./...` (fails: c.OutstandingBalance undefined)

------
https://chatgpt.com/codex/tasks/task_e_68a8ad1fb67c832cb7d39029d8099001