### PR TITLE
chore: rely on JWT for company and location context

### DIFF
--- a/next_frontend_web/src/context/MainContext.tsx
+++ b/next_frontend_web/src/context/MainContext.tsx
@@ -2,7 +2,6 @@ import React, { createContext, useContext, useReducer, ReactNode, useEffect, use
 import { AppState, AppAction, Product, Category, Customer, Sale, Supplier } from '../types';
 import { products, categories, customers, sales, dashboard, suppliers } from '../services';
 import { useAuth } from './AuthContext';
-import { setCompanyLocation } from '../services/apiClient';
 
 export const SYNC_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -176,10 +175,6 @@ export const MainProvider = ({ children }: { children: ReactNode }) => {
       }
     }
   }, [state.theme, state.language, state.lastSync, state.unsyncedSales]);
-
-  useEffect(() => {
-    setCompanyLocation(state.currentCompanyId, state.currentLocationId);
-  }, [state.currentCompanyId, state.currentLocationId]);
 
   const syncUnsyncedSales = async () => {
     if (!state.unsyncedSales.length) return;

--- a/next_frontend_web/src/services/apiClient.ts
+++ b/next_frontend_web/src/services/apiClient.ts
@@ -2,8 +2,6 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
 
 let accessToken: string | null = null;
 let refreshToken: string | null = null;
-let companyId: string | null = null;
-let locationId: string | null = null;
 
 const getCookie = (name: string): string | null => {
   if (typeof document === 'undefined') return null;
@@ -47,14 +45,6 @@ export const clearAuthTokens = () => {
   refreshToken = null;
   deleteCookie('accessToken');
   deleteCookie('refreshToken');
-};
-
-export const setCompanyLocation = (
-  company: string | null,
-  location: string | null
-) => {
-  companyId = company;
-  locationId = location;
 };
 
 const toSnakeCase = (obj: any): any => {
@@ -107,12 +97,6 @@ async function request<T>(endpoint: string, options: RequestOptions = {}): Promi
 
   if (auth && accessToken) {
     (config.headers as Record<string, string>)['Authorization'] = `Bearer ${accessToken}`;
-  }
-  if (companyId) {
-    (config.headers as Record<string, string>)['company_id'] = companyId;
-  }
-  if (locationId) {
-    (config.headers as Record<string, string>)['location_id'] = locationId;
   }
 
   let response = await fetch(`${API_BASE_URL}${endpoint}`, config);


### PR DESCRIPTION
## Summary
- remove company_id and location_id header injection in API client
- drop now-unneeded setCompanyLocation hook usage

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `go test ./...` (fails: c.OutstandingBalance undefined)


------
https://chatgpt.com/codex/tasks/task_e_68a8aeac724c832c9014e4d1a3cd18aa