### PR TITLE
Add services for core admin and HR endpoints

### DIFF
--- a/go_backend_rmt/internal/routes/FRONTEND_PARITY.md
+++ b/go_backend_rmt/internal/routes/FRONTEND_PARITY.md
@@ -1,0 +1,55 @@
+# Frontend Coverage of Backend Routes
+
+The table below tracks whether each backend route group in `routes.go` has a corresponding frontend service module.
+
+| Route Group | Frontend Module | Notes |
+|-------------|----------------|-------|
+| `/auth` | `src/services/auth.ts` | |
+| `/device-sessions` | — | Not used in frontend yet |
+| `/dashboard` | `src/services/dashboard.ts` | |
+| `/users` | `src/services/users.ts` | Added for parity |
+| `/companies` | `src/services/companies.ts` | |
+| `/locations` | `src/services/locations.ts` | Added for parity |
+| `/roles` | `src/services/roles.ts` | Added for parity |
+| `/permissions` | `src/services/roles.ts` | Exposed via getPermissions |
+| `/products` | `src/services/products.ts` | |
+| `/categories` | `src/services/categories.ts` | |
+| `/brands` | — | Not currently used |
+| `/units` | — | Not currently used |
+| `/product-attribute-definitions` | — | Not currently used |
+| `/inventory` | `src/services/inventory.ts` | |
+| `/sales` | `src/services/sales.ts` | Quote helpers pending |
+| `/pos` | — | POS UI not implemented |
+| `/loyalty-programs` | — | Reserved for future feature |
+| `/loyalty-redemptions` | — | Reserved for future feature |
+| `/loyalty` | — | Reserved for future feature |
+| `/promotions` | — | Reserved for future feature |
+| `/sale-returns` | — | Reserved for future feature |
+| `/purchases` | `src/services/purchases.ts` | Listing endpoints not used |
+| `/purchase-orders` | `src/services/purchases.ts` | |
+| `/goods-receipts` | `src/services/purchases.ts` | |
+| `/purchase-returns` | `src/services/purchases.ts` | |
+| `/customers` | `src/services/customers.ts` | |
+| `/employees` | `src/services/employees.ts` | Added for parity |
+| `/attendance` | `src/services/attendance.ts` | Added for parity |
+| `/payrolls` | — | Not currently used |
+| `/collections` | — | Not currently used |
+| `/expenses` | — | Not currently used |
+| `/vouchers` | `src/services/accounting.ts` | |
+| `/ledgers` | `src/services/accounting.ts` | |
+| `/cash-registers` | `src/services/accounting.ts` | |
+| `/reports` | — | Not currently used |
+| `/suppliers` | `src/services/suppliers.ts` | |
+| `/currencies` | — | Not currently used |
+| `/taxes` | — | Not currently used |
+| `/settings` | — | Not currently used |
+| `/audit-logs` | — | Not currently used |
+| `/languages` | — | Not currently used |
+| `/translations` | — | Not currently used |
+| `/user-preferences` | — | Not currently used |
+| `/numbering-sequences` | — | Not currently used |
+| `/invoice-templates` | — | Not currently used |
+| `/print` | — | Not currently used |
+| `/workflow-requests` | — | Not currently used |
+
+This document should be updated whenever new service modules are created or an unused endpoint becomes active.

--- a/next_frontend_web/src/services/attendance.ts
+++ b/next_frontend_web/src/services/attendance.ts
@@ -1,0 +1,33 @@
+import api from './apiClient';
+import { AttendanceRecord } from '../types';
+
+export const checkIn = (employeeId: string) =>
+  api.post('/api/v1/attendance/check-in', { employeeId });
+
+export const checkOut = (employeeId: string) =>
+  api.post('/api/v1/attendance/check-out', { employeeId });
+
+export const applyLeave = (payload: {
+  employeeId: string;
+  startDate: string;
+  endDate: string;
+  reason?: string;
+}) => api.post('/api/v1/attendance/leave', payload);
+
+export const getHolidays = () =>
+  api.get<string[]>('/api/v1/attendance/holidays');
+
+export interface AttendanceQuery {
+  employeeId?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+export const getAttendanceRecords = (query: AttendanceQuery = {}) => {
+  const params = new URLSearchParams();
+  if (query.employeeId) params.append('employee_id', query.employeeId);
+  if (query.startDate) params.append('start_date', query.startDate);
+  if (query.endDate) params.append('end_date', query.endDate);
+  const qs = params.toString();
+  return api.get<AttendanceRecord[]>(`/api/v1/attendance/records${qs ? `?${qs}` : ''}`);
+};

--- a/next_frontend_web/src/services/employees.ts
+++ b/next_frontend_web/src/services/employees.ts
@@ -1,0 +1,13 @@
+import api from './apiClient';
+import { Employee } from '../types';
+
+export const getEmployees = () => api.get<Employee[]>('/api/v1/employees');
+
+export const createEmployee = (payload: Partial<Employee>) =>
+  api.post<Employee>('/api/v1/employees', payload);
+
+export const updateEmployee = (id: string, payload: Partial<Employee>) =>
+  api.put<void>(`/api/v1/employees/${id}`, payload);
+
+export const deleteEmployee = (id: string) =>
+  api.delete<void>(`/api/v1/employees/${id}`);

--- a/next_frontend_web/src/services/index.ts
+++ b/next_frontend_web/src/services/index.ts
@@ -10,3 +10,8 @@ export * as inventory from './inventory';
 export * as purchases from './purchases';
 export * as suppliers from './suppliers';
 export * as accounting from './accounting';
+export * as users from './users';
+export * as roles from './roles';
+export * as locations from './locations';
+export * as employees from './employees';
+export * as attendance from './attendance';

--- a/next_frontend_web/src/services/locations.ts
+++ b/next_frontend_web/src/services/locations.ts
@@ -1,0 +1,13 @@
+import api from './apiClient';
+import { Location } from '../types';
+
+export const getLocations = () => api.get<Location[]>('/api/v1/locations');
+
+export const createLocation = (payload: Partial<Location>) =>
+  api.post<Location>('/api/v1/locations', payload);
+
+export const updateLocation = (id: string, payload: Partial<Location>) =>
+  api.put<void>(`/api/v1/locations/${id}`, payload);
+
+export const deleteLocation = (id: string) =>
+  api.delete<void>(`/api/v1/locations/${id}`);

--- a/next_frontend_web/src/services/roles.ts
+++ b/next_frontend_web/src/services/roles.ts
@@ -1,0 +1,22 @@
+import api from './apiClient';
+import { Role } from '../types';
+
+export const getRoles = () => api.get<Role[]>('/api/v1/roles');
+
+export const createRole = (payload: Partial<Role>) =>
+  api.post<Role>('/api/v1/roles', payload);
+
+export const updateRole = (id: string, payload: Partial<Role>) =>
+  api.put<void>(`/api/v1/roles/${id}`, payload);
+
+export const deleteRole = (id: string) =>
+  api.delete<void>(`/api/v1/roles/${id}`);
+
+export const getRolePermissions = (id: string) =>
+  api.get<string[]>(`/api/v1/roles/${id}/permissions`);
+
+export const assignPermissions = (id: string, permissions: string[]) =>
+  api.post<void>(`/api/v1/roles/${id}/permissions`, { permissions });
+
+export const getPermissions = () =>
+  api.get<string[]>('/api/v1/permissions');

--- a/next_frontend_web/src/services/users.ts
+++ b/next_frontend_web/src/services/users.ts
@@ -1,0 +1,13 @@
+import api from './apiClient';
+import { User } from '../types';
+
+export const getUsers = () => api.get<User[]>('/api/v1/users');
+
+export const createUser = (payload: Partial<User>) =>
+  api.post<{ userId: string }>('/api/v1/users', payload);
+
+export const updateUser = (id: string, payload: Partial<User>) =>
+  api.put<void>(`/api/v1/users/${id}`, payload);
+
+export const deleteUser = (id: string) =>
+  api.delete<void>(`/api/v1/users/${id}`);

--- a/next_frontend_web/src/types/index.ts
+++ b/next_frontend_web/src/types/index.ts
@@ -195,6 +195,33 @@ export interface Supplier extends AuditFields {
   notes?: string;
 }
 
+export interface Role extends AuditFields {
+  _id: string;
+  name: string;
+  permissions: string[];
+  companyId: string;
+}
+
+export interface Employee extends AuditFields {
+  _id: string;
+  name: string;
+  phone?: string;
+  email?: string;
+  position?: string;
+  department?: string;
+  companyId: string;
+  locationId?: string;
+  isActive: boolean;
+}
+
+export interface AttendanceRecord extends AuditFields {
+  _id: string;
+  employeeId: string;
+  type: 'check-in' | 'check-out' | 'leave';
+  timestamp: string;
+  note?: string;
+}
+
 export type SidebarView =
   | 'dashboard'
   | 'sales'


### PR DESCRIPTION
## Summary
- add frontend service modules for users, roles, locations, employees and attendance
- document route coverage vs frontend services
- define types for Role, Employee and AttendanceRecord

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `go test ./...` *(fails: c.OutstandingBalance undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b145c06c832cb4b591d6e2babd93