### PR TITLE
Ensure consistent success responses and add API spec

### DIFF
--- a/go_backend_rmt/internal/utils/response.go
+++ b/go_backend_rmt/internal/utils/response.go
@@ -10,6 +10,9 @@ import (
 
 // SuccessResponse sends a success response
 func SuccessResponse(c *gin.Context, message string, data interface{}) {
+	if data == nil {
+		data = gin.H{}
+	}
 	response := models.APIResponse{
 		Success: true,
 		Message: message,
@@ -20,6 +23,9 @@ func SuccessResponse(c *gin.Context, message string, data interface{}) {
 
 // CreatedResponse sends a created response
 func CreatedResponse(c *gin.Context, message string, data interface{}) {
+	if data == nil {
+		data = gin.H{}
+	}
 	response := models.APIResponse{
 		Success: true,
 		Message: message,

--- a/go_backend_rmt/openapi.yaml
+++ b/go_backend_rmt/openapi.yaml
@@ -1,0 +1,50 @@
+openapi: 3.0.0
+info:
+  title: EBS Lite API
+  version: "1.0.0"
+servers:
+  - url: /api
+paths:
+  /employees:
+    get:
+      summary: List employees
+      responses:
+        '200':
+          description: A list of employees
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIResponse'
+  /employees/{id}:
+    get:
+      summary: Get employee by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Employee retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIResponse'
+components:
+  schemas:
+    APIResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        data:
+          type: object
+          additionalProperties: true
+        error:
+          type: string
+        meta:
+          type: object
+          additionalProperties: true


### PR DESCRIPTION
## Summary
- Return empty objects when handlers don't supply data so `data` is always present in success responses
- Introduce a starter OpenAPI spec documenting employee endpoints and standard API response shape

## Testing
- `go test ./internal/utils -run TestNonExisting` *(fails: hangs, possibly due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b35b43b4832c89f23532a51312cf