### PR TITLE
fix: supply device id for login and correct customer credit types

### DIFF
--- a/next_frontend_web/src/components/Auth/LoginPage.tsx
+++ b/next_frontend_web/src/components/Auth/LoginPage.tsx
@@ -17,6 +17,12 @@ const LoginPage: React.FC = () => {
     clearError();
   }, []);
 
+  useEffect(() => {
+    if (state.isAuthenticated) {
+      router.replace('/dashboard');
+    }
+  }, [state.isAuthenticated, router]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {

--- a/next_frontend_web/src/services/customers.ts
+++ b/next_frontend_web/src/services/customers.ts
@@ -16,11 +16,13 @@ export const updateCustomerCredit = (
   type: "credit" | "debit",
   description: string,
 ) =>
-  api.post<CreditTransaction>(`/api/v1/customers/${id}/credit`, {
-    amount,
-    type,
-    description,
-  });
+  api
+    .post<ApiResponse<Customer>>(`/api/v1/customers/${id}/credit`, {
+      amount,
+      type,
+      description,
+    })
+    .then((res) => res.data!);
 export const getCustomerCreditHistory = (id: string) =>
   api.get<CreditTransaction[]>(`/api/v1/customers/${id}/credit`);
 export const searchCustomers = (query: string) =>

--- a/next_frontend_web/src/services/inventory.ts
+++ b/next_frontend_web/src/services/inventory.ts
@@ -11,7 +11,7 @@ export const adjustStock = (payload: {
 }) => api.post<void>('/api/v1/inventory/stock-adjustment', payload);
 
 export const getStockAdjustments = () =>
-  api.get(`/api/v1/inventory/stock-adjustments`);
+  api.get<any[]>(`/api/v1/inventory/stock-adjustments`);
 
 export const createTransfer = (payload: {
   toLocationId: string;
@@ -19,4 +19,4 @@ export const createTransfer = (payload: {
   notes?: string;
 }) => api.post('/api/v1/inventory/transfers', payload);
 
-export const getTransfers = () => api.get('/api/v1/inventory/transfers');
+export const getTransfers = () => api.get<any[]>('/api/v1/inventory/transfers');

--- a/next_frontend_web/src/types/index.ts
+++ b/next_frontend_web/src/types/index.ts
@@ -518,7 +518,7 @@ type AuthAction =
   | { type: 'LOGIN_FAILURE'; payload: string }
   | { type: 'LOGOUT' }
   | { type: 'REGISTER_START' }
-  | { type: 'REGISTER_SUCCESS'; payload: { user: User; company: Company } }
+  | { type: 'REGISTER_SUCCESS' }
   | { type: 'REGISTER_FAILURE'; payload: string }
   | { type: 'CLEAR_ERROR' }
   | { type: 'UPDATE_USER_LANGUAGES'; payload: { primaryLanguage: string; secondaryLanguage?: string } };


### PR DESCRIPTION
## Summary
- persist a device identifier and include it when invoking the login API
- treat registration as a separate flow and adjust auth action types
- return updated customer data when adjusting credit balances
- redirect authenticated users to the dashboard
- skip profile fetch when no auth token is present to avoid unauthorized calls

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8b6430cc8832cbae4bda3f4074e5f