### PR TITLE
Fix duplicate getDeviceId in AuthContext

### DIFF
--- a/next_frontend_web/src/context/AuthContext.tsx
+++ b/next_frontend_web/src/context/AuthContext.tsx
@@ -82,18 +82,6 @@ const getDeviceId = (): string => {
   return id;
 };
 
-const getDeviceId = (): string => {
-  if (typeof window === 'undefined') return '';
-  let id = localStorage.getItem('deviceId');
-  if (!id) {
-    const generate = () =>
-      globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2);
-    id = generate();
-    localStorage.setItem('deviceId', id);
-  }
-  return id;
-};
-
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [state, dispatch] = useReducer(authReducer, initialState);
 


### PR DESCRIPTION
## Summary
- remove duplicate `getDeviceId` declaration causing type errors

## Testing
- `npm test` (fails: missing script)
- `npm run lint`
- `npm run build` (terminated early after generating static pages)


------
https://chatgpt.com/codex/tasks/task_e_68a9e8abeb28832c97f9caa47fcf17b9