### PR TITLE
fix: handle post-login redirects by user role

### DIFF
--- a/next_frontend_web/src/components/Auth/LoginPage.tsx
+++ b/next_frontend_web/src/components/Auth/LoginPage.tsx
@@ -2,9 +2,10 @@ import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import { Eye, EyeOff, LogIn, Building, User, AlertCircle } from 'lucide-react';
+import { getInitialRoute } from '../../utils/routes';
 
 const LoginPage: React.FC = () => {
-  const { state, login, clearError } = useAuth();
+  const { state, login, clearError, hasRole } = useAuth();
   const router = useRouter();
   const [showPassword, setShowPassword] = useState(false);
   const [formData, setFormData] = useState({
@@ -19,9 +20,9 @@ const LoginPage: React.FC = () => {
 
   useEffect(() => {
     if (state.isAuthenticated) {
-      router.replace('/dashboard');
+      router.replace(getInitialRoute(hasRole));
     }
-  }, [state.isAuthenticated, router]);
+  }, [state.isAuthenticated, hasRole, router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/next_frontend_web/src/components/Auth/RoleGuard.tsx
+++ b/next_frontend_web/src/components/Auth/RoleGuard.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
+import { getInitialRoute } from '../../utils/routes';
 
 interface RoleGuardProps {
   roles: string[];
@@ -16,7 +17,7 @@ const RoleGuard: React.FC<RoleGuardProps> = ({ roles, children }) => {
     if (!state.isAuthenticated) {
       router.replace('/login');
     } else if (!hasRole(roles)) {
-      router.replace('/dashboard');
+      router.replace(getInitialRoute(hasRole));
     }
   }, [state.isInitialized, state.isAuthenticated, state.user, roles, router, hasRole]);
 

--- a/next_frontend_web/src/pages/index.tsx
+++ b/next_frontend_web/src/pages/index.tsx
@@ -1,18 +1,19 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useAuth } from '../context/AuthContext';
+import { getInitialRoute } from '../utils/routes';
 
 const IndexPage: React.FC = () => {
-  const { state } = useAuth();
+  const { state, hasRole } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
     if (state.isAuthenticated) {
-      router.replace('/dashboard');
+      router.replace(getInitialRoute(hasRole));
     } else {
       router.replace('/login');
     }
-  }, [state.isAuthenticated, router]);
+  }, [state.isAuthenticated, hasRole, router]);
 
   return null;
 };

--- a/next_frontend_web/src/pages/login.tsx
+++ b/next_frontend_web/src/pages/login.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../context/AuthContext';
 import { useAppActions } from '../context/MainContext';
 import { LoginPage } from '../components/Auth/LoginPage';
+import { getInitialRoute } from '../utils/routes';
 
 const Login: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const Login: React.FC = () => {
       if (defaultLocation) {
         setCurrentLocation(defaultLocation);
       }
-      const target = hasRole('Admin') ? '/dashboard' : '/sales';
+      const target = getInitialRoute(hasRole);
       router.replace(target);
     }
   }, [state.isAuthenticated, state.company, hasRole, router, setCurrentCompany, setCurrentLocation]);

--- a/next_frontend_web/src/utils/routes.ts
+++ b/next_frontend_web/src/utils/routes.ts
@@ -1,0 +1,8 @@
+export const getInitialRoute = (hasRole: (roles: string | string[]) => boolean): string => {
+  if (hasRole(['Admin', 'Manager', 'User'])) return '/dashboard';
+  if (hasRole('Sales')) return '/sales';
+  if (hasRole('Store')) return '/inventory';
+  if (hasRole('HR')) return '/hr';
+  if (hasRole('Accountant')) return '/accounting';
+  return '/dashboard';
+};


### PR DESCRIPTION
## Summary
- add role-aware helper for selecting initial route
- redirect users after login and on guarded pages based on roles
- prevent infinite redirects for unauthorized roles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9ebfa6520832cb40005a7511221bf