### PR TITLE
fix: handle post-login redirects by user role

### DIFF
--- a/next_frontend_web/src/components/Auth/LoginPage.tsx
+++ b/next_frontend_web/src/components/Auth/LoginPage.tsx
@@ -2,9 +2,10 @@ import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import { Eye, EyeOff, LogIn, Building, User, AlertCircle } from 'lucide-react';
+import { getInitialRoute } from '../../utils/routes';
 
 const LoginPage: React.FC = () => {
-  const { state, login, clearError } = useAuth();
+  const { state, login, clearError, hasRole } = useAuth();
   const router = useRouter();
   const [showPassword, setShowPassword] = useState(false);
   const [formData, setFormData] = useState({
@@ -19,9 +20,9 @@ const LoginPage: React.FC = () => {
 
   useEffect(() => {
     if (state.isAuthenticated) {
-      router.replace('/dashboard');
+      router.replace(getInitialRoute(hasRole));
     }
-  }, [state.isAuthenticated, router]);
+  }, [state.isAuthenticated, hasRole, router]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/next_frontend_web/src/components/Auth/RoleGuard.tsx
+++ b/next_frontend_web/src/components/Auth/RoleGuard.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
+import { getInitialRoute } from '../../utils/routes';
 
 interface RoleGuardProps {
   roles: string[];
@@ -15,8 +16,11 @@ const RoleGuard: React.FC<RoleGuardProps> = ({ roles, children }) => {
     if (!state.isInitialized) return;
     if (!state.isAuthenticated) {
       router.replace('/login');
-    } else if (!hasRole(roles)) {
-      router.replace('/dashboard');
+      return;
+    }
+    if (!hasRole(roles)) {
+      const target = getInitialRoute(hasRole);
+      router.replace(router.pathname !== target ? target : '/login');
     }
   }, [state.isInitialized, state.isAuthenticated, state.user, roles, router, hasRole]);
 

--- a/next_frontend_web/src/pages/accounting/cash-register.tsx
+++ b/next_frontend_web/src/pages/accounting/cash-register.tsx
@@ -3,7 +3,7 @@ import RoleGuard from '../../components/Auth/RoleGuard';
 import CashRegister from '../../components/ERP/Accounting/CashRegister';
 
 const CashRegisterPage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager']}>
+  <RoleGuard roles={['admin', 'manager', 'accountant']}>
     <MainLayout>
       <CashRegister />
     </MainLayout>

--- a/next_frontend_web/src/pages/accounting/ledger.tsx
+++ b/next_frontend_web/src/pages/accounting/ledger.tsx
@@ -3,7 +3,7 @@ import RoleGuard from '../../components/Auth/RoleGuard';
 import LedgerView from '../../components/ERP/Accounting/LedgerView';
 
 const LedgerPage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager']}>
+  <RoleGuard roles={['admin', 'manager', 'accountant']}>
     <MainLayout>
       <LedgerView />
     </MainLayout>

--- a/next_frontend_web/src/pages/accounting/voucher-entry.tsx
+++ b/next_frontend_web/src/pages/accounting/voucher-entry.tsx
@@ -3,7 +3,7 @@ import RoleGuard from '../../components/Auth/RoleGuard';
 import VoucherEntry from '../../components/ERP/Accounting/VoucherEntry';
 
 const VoucherEntryPage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager']}>
+  <RoleGuard roles={['admin', 'manager', 'accountant']}>
     <MainLayout>
       <VoucherEntry />
     </MainLayout>

--- a/next_frontend_web/src/pages/index.tsx
+++ b/next_frontend_web/src/pages/index.tsx
@@ -1,18 +1,19 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useAuth } from '../context/AuthContext';
+import { getInitialRoute } from '../utils/routes';
 
 const IndexPage: React.FC = () => {
-  const { state } = useAuth();
+  const { state, hasRole } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
     if (state.isAuthenticated) {
-      router.replace('/dashboard');
+      router.replace(getInitialRoute(hasRole));
     } else {
       router.replace('/login');
     }
-  }, [state.isAuthenticated, router]);
+  }, [state.isAuthenticated, hasRole, router]);
 
   return null;
 };

--- a/next_frontend_web/src/pages/inventory/adjustments.tsx
+++ b/next_frontend_web/src/pages/inventory/adjustments.tsx
@@ -3,7 +3,7 @@ import RoleGuard from '../../components/Auth/RoleGuard';
 import StockAdjustments from '../../components/ERP/Inventory/StockAdjustments';
 
 const StockAdjustmentsPage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager']}>
+  <RoleGuard roles={['admin', 'manager', 'store']}>
     <MainLayout>
       <StockAdjustments />
     </MainLayout>

--- a/next_frontend_web/src/pages/inventory/barcode.tsx
+++ b/next_frontend_web/src/pages/inventory/barcode.tsx
@@ -3,7 +3,7 @@ import RoleGuard from '../../components/Auth/RoleGuard';
 import BarcodeLabelPrinter from '../../components/ERP/Inventory/BarcodeLabelPrinter';
 
 const BarcodePage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager']}>
+  <RoleGuard roles={['admin', 'manager', 'store']}>
     <MainLayout>
       <BarcodeLabelPrinter />
     </MainLayout>

--- a/next_frontend_web/src/pages/inventory/index.tsx
+++ b/next_frontend_web/src/pages/inventory/index.tsx
@@ -3,7 +3,7 @@ import RoleGuard from '../../components/Auth/RoleGuard';
 import ProductManagement from '../../components/ERP/Inventory/ProductManagement';
 
 const InventoryPage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager']}>
+  <RoleGuard roles={['admin', 'manager', 'store']}>
     <MainLayout>
       <ProductManagement />
     </MainLayout>

--- a/next_frontend_web/src/pages/inventory/product/[id].tsx
+++ b/next_frontend_web/src/pages/inventory/product/[id].tsx
@@ -3,7 +3,7 @@ import RoleGuard from '../../../components/Auth/RoleGuard';
 import ProductDetail from '../../../components/ERP/Inventory/ProductDetail';
 
 const ProductDetailPage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager']}>
+  <RoleGuard roles={['admin', 'manager', 'store']}>
     <MainLayout>
       <ProductDetail />
     </MainLayout>

--- a/next_frontend_web/src/pages/inventory/transfer.tsx
+++ b/next_frontend_web/src/pages/inventory/transfer.tsx
@@ -3,7 +3,7 @@ import RoleGuard from '../../components/Auth/RoleGuard';
 import TransferRequest from '../../components/ERP/Inventory/TransferRequest';
 
 const TransferPage: React.FC = () => (
-  <RoleGuard roles={['admin', 'manager']}>
+  <RoleGuard roles={['admin', 'manager', 'store']}>
     <MainLayout>
       <TransferRequest />
     </MainLayout>

--- a/next_frontend_web/src/pages/login.tsx
+++ b/next_frontend_web/src/pages/login.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../context/AuthContext';
 import { useAppActions } from '../context/MainContext';
 import { LoginPage } from '../components/Auth/LoginPage';
+import { getInitialRoute } from '../utils/routes';
 
 const Login: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const Login: React.FC = () => {
       if (defaultLocation) {
         setCurrentLocation(defaultLocation);
       }
-      const target = hasRole('Admin') ? '/dashboard' : '/sales';
+      const target = getInitialRoute(hasRole);
       router.replace(target);
     }
   }, [state.isAuthenticated, state.company, hasRole, router, setCurrentCompany, setCurrentLocation]);

--- a/next_frontend_web/src/utils/routes.ts
+++ b/next_frontend_web/src/utils/routes.ts
@@ -1,0 +1,8 @@
+export const getInitialRoute = (hasRole: (roles: string | string[]) => boolean): string => {
+  if (hasRole(['Admin', 'Manager', 'User'])) return '/dashboard';
+  if (hasRole('Sales')) return '/sales';
+  if (hasRole('Store')) return '/inventory';
+  if (hasRole('HR')) return '/hr';
+  if (hasRole('Accountant')) return '/accounting/ledger';
+  return '/dashboard';
+};


### PR DESCRIPTION
## Summary
- prevent redirect loops by falling back to login when no role-based route exists
- route accountants to an existing ledger page
- allow store and accountant roles to open inventory and accounting screens

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9ebfa6520832cb40005a7511221bf