### PR TITLE
refactor: use numeric role IDs

### DIFF
--- a/next_frontend_web/src/components/Layout/Header.tsx
+++ b/next_frontend_web/src/components/Layout/Header.tsx
@@ -279,7 +279,7 @@ const Header: React.FC = () => {
                 {authState.user?.fullName}
               </div>
               <div className="text-xs text-gray-500 dark:text-gray-400">
-                {authState.user?.role_id}
+                {authState.user?.roleName || authState.user?.roleId}
               </div>
             </div>
 

--- a/next_frontend_web/src/components/Layout/Sidebar.tsx
+++ b/next_frontend_web/src/components/Layout/Sidebar.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useApp } from '../../context/MainContext';
 import { useAuth } from '../../context/AuthContext';
+import { ROLES } from '../../types';
 import {
   ShoppingCart,
   BarChart3,
@@ -38,7 +39,7 @@ interface MenuItem {
   view?: SidebarView;
   subItems?: MenuItem[];
   badge?: number;
-  roles?: string[];
+  roles?: number[];
 }
 
 const Sidebar: React.FC = () => {
@@ -55,12 +56,20 @@ const Sidebar: React.FC = () => {
       icon: Home,
       label: 'Dashboard',
       view: 'dashboard',
-      roles: ['1', 'Manager', 'Sales', 'Store', 'HR', 'Accountant'],
+      roles: [
+        ROLES.SUPER_ADMIN,
+        ROLES.ADMIN,
+        ROLES.MANAGER,
+        ROLES.SALES,
+        ROLES.INVENTORY,
+        ROLES.HR,
+        ROLES.ACCOUNTANT,
+      ],
     },
     {
       icon: ShoppingCart,
       label: 'Sales',
-      roles: ['1', 'Manager', 'Sales'],
+      roles: [ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER, ROLES.SALES],
       subItems: [
         { label: 'POS', view: 'sales', icon: ShoppingCart },
         { label: 'Invoice', view: 'sales-invoice', icon: FileText },
@@ -71,7 +80,7 @@ const Sidebar: React.FC = () => {
     {
       icon: Users,
       label: 'Customers',
-      roles: ['1', 'Manager', 'Sales'],
+      roles: [ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER, ROLES.SALES],
       subItems: [
         { label: 'Collections', view: 'collectionss', icon: Banknote },
         { label: 'Customers', view: 'customers', icon: Users },
@@ -81,7 +90,7 @@ const Sidebar: React.FC = () => {
     {
       icon: Package,
       label: 'Purchases',
-      roles: ['1', 'Manager'],
+      roles: [ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER],
       subItems: [
         { label: 'Purchase Entry', view: 'purchase-entry', icon: ShoppingBag },
         { label: 'Purchase Orders', view: 'purchase-orders', icon: ListOrdered },
@@ -92,7 +101,7 @@ const Sidebar: React.FC = () => {
     {
       icon: Warehouse,
       label: 'Inventory',
-      roles: ['1', 'Manager', 'Store'],
+      roles: [ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER, ROLES.INVENTORY],
       subItems: [
         { label: 'Inventory Summary', view: 'inventory', icon: Eye },
         { label: 'Products', view: 'inventory-products', icon: Package },
@@ -110,7 +119,7 @@ const Sidebar: React.FC = () => {
     {
       icon: DollarSign,
       label: 'Accounting',
-      roles: ['1', 'Manager', 'Accountant'],
+      roles: [ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER, ROLES.ACCOUNTANT],
       subItems: [
         { label: 'Cash Register', view: 'cash-register', icon: DollarSign },
         { label: 'Vouchers', view: 'vouchers', icon: CreditCard },
@@ -121,7 +130,7 @@ const Sidebar: React.FC = () => {
     {
       icon: BarChart3,
       label: 'Reports',
-      roles: ['1', 'Manager', 'Accountant'],
+      roles: [ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER, ROLES.ACCOUNTANT],
       subItems: [
         { label: 'Sales Reports', view: 'sales-reports', icon: BarChart3 },
         { label: 'Inventory Reports', view: 'inventory-reports', icon: Package },
@@ -135,7 +144,7 @@ const Sidebar: React.FC = () => {
     {
       icon: UserCheck,
       label: 'HR',
-      roles: ['1', 'HR'],
+      roles: [ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.HR],
       subItems: [
         { label: 'Employees', view: 'employees', icon: Users },
         { label: 'Attendance', view: 'attendance', icon: History },
@@ -146,7 +155,7 @@ const Sidebar: React.FC = () => {
     {
       icon: Settings,
       label: 'Settings',
-      roles: ['1', 'Manager'],
+      roles: [ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER],
       subItems: [
         { label: 'General', view: 'settings-general', icon: Settings },
         { label: 'Company Settings', view: 'settings-company', icon: Building2 },

--- a/next_frontend_web/src/context/AuthContext.tsx
+++ b/next_frontend_web/src/context/AuthContext.tsx
@@ -14,9 +14,9 @@ interface AuthContextValue {
   register: (userData: any) => Promise<void>;
   logout: () => Promise<void>;
   clearError: () => void;
-  hasRole: (roles: string | string[]) => boolean;
+  hasRole: (roles: number | number[]) => boolean;
   hasPermission: (perms: string | string[]) => boolean;
-  role?: string;
+  roleId?: number;
   permissions: string[];
   updateUserLanguages: (payload: {
     primaryLanguage: string;
@@ -137,13 +137,13 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     dispatch({ type: 'UPDATE_USER_LANGUAGES', payload });
   };
 
-  const role = state.user?.role_id;
+  const roleId = state.user?.roleId;
   const permissions = state.user?.permissions || [];
 
-  const hasRole = (roles: string | string[]) => {
-    if (!role) return false;
+  const hasRole = (roles: number | number[]) => {
+    if (roleId == null) return false;
     const roleList = Array.isArray(roles) ? roles : [roles];
-    return roleList.map(r => r.toLowerCase()).includes(role.toLowerCase());
+    return roleList.includes(roleId);
   };
 
   const hasPermission = (perms: string | string[]) => {
@@ -162,7 +162,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         clearError,
         hasRole,
         hasPermission,
-        role,
+        roleId,
         permissions,
         updateUserLanguages,
       }}

--- a/next_frontend_web/src/pages/accounting/cash-register.tsx
+++ b/next_frontend_web/src/pages/accounting/cash-register.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import CashRegister from '../../components/ERP/Accounting/CashRegister';
+import { ROLES } from '../../types';
 
 const CashRegisterPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const CashRegisterPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/accounting/ledger.tsx
+++ b/next_frontend_web/src/pages/accounting/ledger.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import LedgerView from '../../components/ERP/Accounting/LedgerView';
+import { ROLES } from '../../types';
 
 const LedgerPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const LedgerPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/accounting/voucher-entry.tsx
+++ b/next_frontend_web/src/pages/accounting/voucher-entry.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import VoucherEntry from '../../components/ERP/Accounting/VoucherEntry';
+import { ROLES } from '../../types';
 
 const VoucherEntryPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const VoucherEntryPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/company-create.tsx
+++ b/next_frontend_web/src/pages/company-create.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useAuth } from '../context/AuthContext';
 import { CompanyCreatePage } from '../components/Auth/CompanyCreatePage';
+import { ROLES } from '../types';
 
 const CompanyCreate: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -15,7 +16,7 @@ const CompanyCreate: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN])) return <div>Access denied</div>;
 
   return <CompanyCreatePage />;
 };

--- a/next_frontend_web/src/pages/dashboard/index.tsx
+++ b/next_frontend_web/src/pages/dashboard/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import Dashboard from '../../components/ERP/Dashboard';
+import { ROLES } from '../../types';
 
 const DashboardPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const DashboardPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager', 'user'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER, ROLES.SALES])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/hr/clock.tsx
+++ b/next_frontend_web/src/pages/hr/clock.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import ClockInOut from '../../components/ERP/HR/ClockInOut';
+import { ROLES } from '../../types';
 
 const ClockPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const ClockPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'HR'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.HR])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/hr/index.tsx
+++ b/next_frontend_web/src/pages/hr/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import Link from 'next/link';
+import { ROLES } from '../../types';
 
 const HRDashboard: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const HRDashboard: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'HR'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.HR])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/hr/leave.tsx
+++ b/next_frontend_web/src/pages/hr/leave.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import LeaveCalendar from '../../components/ERP/HR/LeaveCalendar';
+import { ROLES } from '../../types';
 
 const LeavePage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const LeavePage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'HR'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.HR])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/hr/payroll.tsx
+++ b/next_frontend_web/src/pages/hr/payroll.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import SalaryProcessing from '../../components/ERP/HR/SalaryProcessing';
+import { ROLES } from '../../types';
 
 const PayrollPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const PayrollPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'HR'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.HR])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/inventory/adjustments.tsx
+++ b/next_frontend_web/src/pages/inventory/adjustments.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import StockAdjustments from '../../components/ERP/Inventory/StockAdjustments';
+import { ROLES } from '../../types';
 
 const StockAdjustmentsPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const StockAdjustmentsPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/inventory/barcode.tsx
+++ b/next_frontend_web/src/pages/inventory/barcode.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import BarcodeLabelPrinter from '../../components/ERP/Inventory/BarcodeLabelPrinter';
+import { ROLES } from '../../types';
 
 const BarcodePage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const BarcodePage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/inventory/index.tsx
+++ b/next_frontend_web/src/pages/inventory/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import ProductManagement from '../../components/ERP/Inventory/ProductManagement';
+import { ROLES } from '../../types';
 
 const InventoryPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const InventoryPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/inventory/product/[id].tsx
+++ b/next_frontend_web/src/pages/inventory/product/[id].tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../../context/AuthContext';
 import MainLayout from '../../../components/Layout/MainLayout';
 import ProductDetail from '../../../components/ERP/Inventory/ProductDetail';
+import { ROLES } from '../../../types';
 
 const ProductDetailPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const ProductDetailPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/inventory/transfer.tsx
+++ b/next_frontend_web/src/pages/inventory/transfer.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import TransferRequest from '../../components/ERP/Inventory/TransferRequest';
+import { ROLES } from '../../types';
 
 const TransferPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const TransferPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/purchases/grn.tsx
+++ b/next_frontend_web/src/pages/purchases/grn.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import GoodsReceiptForm from '../../components/ERP/Purchase/GoodsReceiptForm';
+import { ROLES } from '../../types';
 
 const GoodsReceiptPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const GoodsReceiptPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/purchases/order.tsx
+++ b/next_frontend_web/src/pages/purchases/order.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import PurchaseOrderForm from '../../components/ERP/Purchase/PurchaseOrderForm';
+import { ROLES } from '../../types';
 
 const PurchaseOrderPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const PurchaseOrderPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/purchases/returns.tsx
+++ b/next_frontend_web/src/pages/purchases/returns.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import PurchaseReturnForm from '../../components/ERP/Purchase/PurchaseReturnForm';
+import { ROLES } from '../../types';
 
 const PurchaseReturnPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const PurchaseReturnPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/purchases/suppliers.tsx
+++ b/next_frontend_web/src/pages/purchases/suppliers.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import SupplierManagement from '../../components/ERP/Purchase/SupplierManagement';
+import { ROLES } from '../../types';
 
 const SuppliersPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const SuppliersPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/register.tsx
+++ b/next_frontend_web/src/pages/register.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useAuth } from '../context/AuthContext';
 import { RegisterPage } from '../components/Auth/RegisterPage';
+import { ROLES } from '../types';
 
 const Register: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -9,7 +10,7 @@ const Register: React.FC = () => {
 
   useEffect(() => {
     if (state.isAuthenticated) {
-      const target = hasRole('1') ? '/dashboard' : '/sales';
+      const target = hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN]) ? '/dashboard' : '/sales';
       router.replace(target);
     }
   }, [state.isAuthenticated, hasRole, router]);

--- a/next_frontend_web/src/pages/reports/customers.tsx
+++ b/next_frontend_web/src/pages/reports/customers.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import CustomersReport from '../../components/ERP/Reports/CustomersReport';
+import { ROLES } from '../../types';
 
 const CustomersReportPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const CustomersReportPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/reports/inventory.tsx
+++ b/next_frontend_web/src/pages/reports/inventory.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import InventoryReport from '../../components/ERP/Reports/InventoryReport';
+import { ROLES } from '../../types';
 
 const InventoryReportPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const InventoryReportPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/reports/sales.tsx
+++ b/next_frontend_web/src/pages/reports/sales.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import SalesReport from '../../components/ERP/Reports/SalesReport';
+import { ROLES } from '../../types';
 
 const SalesReportPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const SalesReportPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'manager'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/sales/history.tsx
+++ b/next_frontend_web/src/pages/sales/history.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import SalesHistory from '../../components/ERP/Sales/SalesHistory';
+import { ROLES } from '../../types';
 
 const SalesHistoryPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const SalesHistoryPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'Manager', 'Sales'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER, ROLES.SALES])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/sales/index.tsx
+++ b/next_frontend_web/src/pages/sales/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import SalesInterface from '../../components/ERP/Sales/SalesInterface';
+import { ROLES } from '../../types';
 
 const SalesPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const SalesPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'Manager', 'Sales'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER, ROLES.SALES])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/sales/invoice.tsx
+++ b/next_frontend_web/src/pages/sales/invoice.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import InvoiceView from '../../components/ERP/Sales/InvoiceView';
+import { ROLES } from '../../types';
 
 const InvoicePage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const InvoicePage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'Manager', 'Sales'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER, ROLES.SALES])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/sales/quick.tsx
+++ b/next_frontend_web/src/pages/sales/quick.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import ClassicPOS from '../../components/ERP/Sales/ClassicPOS';
+import { ROLES } from '../../types';
 
 const QuickSalesPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const QuickSalesPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'Manager', 'Sales'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER, ROLES.SALES])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/pages/sales/returns.tsx
+++ b/next_frontend_web/src/pages/sales/returns.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
 import ModernPOS from '../../components/ERP/Sales/ModernPOS';
+import { ROLES } from '../../types';
 
 const ReturnsPage: React.FC = () => {
   const { state, hasRole } = useAuth();
@@ -16,7 +17,7 @@ const ReturnsPage: React.FC = () => {
   }, [state.isInitialized, state.isAuthenticated, router]);
 
   if (!state.isInitialized || !state.isAuthenticated) return null;
-  if (!hasRole(['1', 'Manager', 'Sales'])) return <div>Access denied</div>;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER, ROLES.SALES])) return <div>Access denied</div>;
 
   return (
     <MainLayout>

--- a/next_frontend_web/src/types/index.ts
+++ b/next_frontend_web/src/types/index.ts
@@ -1,10 +1,22 @@
+export enum ROLES {
+  SUPER_ADMIN = 1,
+  ADMIN,
+  MANAGER,
+  SALES,
+  INVENTORY,
+  ACCOUNTANT,
+  CASHIER,
+  HR,
+}
+
 export interface User {
   _id: string;
   username: string;
   email: string;
   fullName: string;
-  //1=Super 1, 2=1, 3=Manager, 4=Sales, 5=Inventory, 6=Accountant, 7=Cashier
-  role_id: '1' | '2' | '3' | '4' | '5' | '6' | '7';
+  // 1=Super Admin, 2=Admin, 3=Manager, 4=Sales, 5=Inventory, 6=Accountant, 7=Cashier, 8=HR
+  roleId: number;
+  roleName?: string;
   companyId: string;
   isActive: boolean;
   permissions: string[];
@@ -533,6 +545,7 @@ type AuthAction =
     isInitialized: boolean;
   }
 
+export { ROLES };
 export type {
   User as UserType,
   Company as CompanyType,
@@ -541,5 +554,6 @@ export type {
   Customer as CustomerType,
   Sale as SaleType,
   Supplier as SupplierType,
-  AuthAction, AppAction
+  AuthAction,
+  AppAction,
 };

--- a/next_frontend_web/src/utils/routes.ts
+++ b/next_frontend_web/src/utils/routes.ts
@@ -1,8 +1,10 @@
-export const getInitialRoute = (hasRole: (roles: string | string[]) => boolean): string => {
-  if (hasRole(['1', 'Manager', 'User'])) return '/dashboard';
-  if (hasRole('Sales')) return '/sales';
-  if (hasRole('Store')) return '/inventory';
-  if (hasRole('HR')) return '/hr';
-  if (hasRole('Accountant')) return '/accounting';
+import { ROLES } from '../types';
+
+export const getInitialRoute = (hasRole: (roles: number | number[]) => boolean): string => {
+  if (hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER])) return '/dashboard';
+  if (hasRole(ROLES.SALES)) return '/sales';
+  if (hasRole(ROLES.INVENTORY)) return '/inventory';
+  if (hasRole(ROLES.HR)) return '/hr';
+  if (hasRole(ROLES.ACCOUNTANT)) return '/accounting';
   return '/dashboard';
 };


### PR DESCRIPTION
## Summary
- replace string-based `role_id` with numeric `roleId` and optional `roleName`
- add `ROLES` enum and update auth context and routing to use numeric role IDs
- update sidebar and protected pages to check roles by numeric ID

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68aa023519f8832c960e52033a576367