### PR TITLE
Ignore generated Flutter icon assets

### DIFF
--- a/flutter_app/.gitignore
+++ b/flutter_app/.gitignore
@@ -1,0 +1,2 @@
+# Ignore generated PNG assets
+**/*.png

--- a/flutter_app/README.md
+++ b/flutter_app/README.md
@@ -1,0 +1,9 @@
+# Flutter App
+
+Generated icon assets are not stored in version control. Regenerate them locally with:
+
+```sh
+flutter pub run flutter_launcher_icons
+```
+
+This command creates icons under `Assets.xcassets` and `mipmap-*` directories.


### PR DESCRIPTION
## Summary
- prevent committing generated Flutter PNG assets
- document how to regenerate icons with `flutter_launcher_icons`

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68aadf3f2f8c832c960e74be41b3edaf