### PR TITLE
feat: add authentication screens with backend integration

### DIFF
--- a/flutter_app/lib/core/app_theme.dart
+++ b/flutter_app/lib/core/app_theme.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+final ThemeData appTheme = ThemeData(
+  colorScheme: const ColorScheme.light(
+    primary: Colors.black,
+    secondary: Colors.red,
+    surface: Colors.white,
+  ),
+  scaffoldBackgroundColor: Colors.white,
+  useMaterial3: true,
+);

--- a/flutter_app/lib/features/auth/controllers/auth_notifier.dart
+++ b/flutter_app/lib/features/auth/controllers/auth_notifier.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/auth_repository.dart';
+import '../data/models.dart';
+
+class AuthState {
+  final bool isLoading;
+  final User? user;
+  final Company? company;
+  final String? error;
+
+  const AuthState({
+    this.isLoading = false,
+    this.user,
+    this.company,
+    this.error,
+  });
+
+  AuthState copyWith({
+    bool? isLoading,
+    User? user,
+    Company? company,
+    String? error,
+  }) {
+    return AuthState(
+      isLoading: isLoading ?? this.isLoading,
+      user: user ?? this.user,
+      company: company ?? this.company,
+      error: error,
+    );
+  }
+}
+
+class AuthNotifier extends StateNotifier<AuthState> {
+  AuthNotifier(this._repository) : super(const AuthState());
+  final AuthRepository _repository;
+
+  Future<LoginResponse?> login({String? username, String? email, required String password}) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final res = await _repository.login(username: username, email: email, password: password);
+      state = state.copyWith(isLoading: false, user: res.user, company: res.company);
+      return res;
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+      return null;
+    }
+  }
+
+  Future<RegisterResponse?> register({
+    required String username,
+    required String email,
+    required String password,
+  }) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final res = await _repository.register(username: username, email: email, password: password);
+      state = state.copyWith(isLoading: false);
+      return res;
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+      return null;
+    }
+  }
+
+  Future<bool> forgotPassword(String email) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      await _repository.forgotPassword(email);
+      state = state.copyWith(isLoading: false);
+      return true;
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+      return false;
+    }
+  }
+
+  Future<bool> resetPassword(String token, String newPassword) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      await _repository.resetPassword(token: token, newPassword: newPassword);
+      state = state.copyWith(isLoading: false);
+      return true;
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+      return false;
+    }
+  }
+
+  Future<Company?> createCompany({required String name, String? email}) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final company = await _repository.createCompany(name: name, email: email);
+      state = state.copyWith(isLoading: false, company: company);
+      return company;
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+      return null;
+    }
+  }
+}
+
+final authNotifierProvider = StateNotifierProvider<AuthNotifier, AuthState>((ref) {
+  final repo = ref.watch(authRepositoryProvider);
+  return AuthNotifier(repo);
+});
+
+final authRepositoryProvider = Provider<AuthRepository>((ref) {
+  throw UnimplementedError();
+});

--- a/flutter_app/lib/features/auth/data/auth_repository.dart
+++ b/flutter_app/lib/features/auth/data/auth_repository.dart
@@ -1,0 +1,82 @@
+import 'package:dio/dio.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+import 'models.dart';
+
+class AuthRepository {
+  AuthRepository(this._dio, this._prefs);
+  final Dio _dio;
+  final SharedPreferences _prefs;
+
+  static const _deviceKey = 'device_id';
+  static const _accessTokenKey = 'access_token';
+  static const _refreshTokenKey = 'refresh_token';
+
+  Future<String> _getDeviceId() async {
+    var id = _prefs.getString(_deviceKey);
+    if (id == null) {
+      id = const Uuid().v4();
+      await _prefs.setString(_deviceKey, id);
+    }
+    return id;
+  }
+
+  Future<LoginResponse> login({
+    String? username,
+    String? email,
+    required String password,
+  }) async {
+    final deviceId = await _getDeviceId();
+    final payload = <String, dynamic>{
+      'password': password,
+      'device_id': deviceId,
+    };
+    if (username != null && username.isNotEmpty) {
+      payload['username'] = username;
+    }
+    if (email != null && email.isNotEmpty) {
+      payload['email'] = email;
+    }
+    final response = await _dio.post('/auth/login', data: payload);
+    final data =
+        LoginResponse.fromJson(response.data['data'] as Map<String, dynamic>);
+    await _prefs.setString(_accessTokenKey, data.accessToken);
+    await _prefs.setString(_refreshTokenKey, data.refreshToken);
+    return data;
+  }
+
+  Future<RegisterResponse> register({
+    required String username,
+    required String email,
+    required String password,
+  }) async {
+    final response = await _dio.post('/auth/register', data: {
+      'username': username,
+      'email': email,
+      'password': password,
+    });
+    return RegisterResponse.fromJson(
+        response.data['data'] as Map<String, dynamic>);
+  }
+
+  Future<void> forgotPassword(String email) async {
+    await _dio.post('/auth/forgot-password', data: {'email': email});
+  }
+
+  Future<void> resetPassword({required String token, required String newPassword}) async {
+    await _dio.post('/auth/reset-password', data: {
+      'token': token,
+      'new_password': newPassword,
+    });
+  }
+
+  Future<Company> createCompany({required String name, String? email}) async {
+    final token = _prefs.getString(_accessTokenKey);
+    final response = await _dio.post('/companies',
+        data: {'name': name, if (email != null) 'email': email},
+        options: Options(headers: {'Authorization': 'Bearer $token'}));
+    return Company.fromJson(
+        response.data['data'] as Map<String, dynamic>);
+  }
+}

--- a/flutter_app/lib/features/auth/data/models.dart
+++ b/flutter_app/lib/features/auth/data/models.dart
@@ -1,0 +1,80 @@
+class User {
+  final int userId;
+  final String username;
+  final String email;
+
+  User({required this.userId, required this.username, required this.email});
+
+  factory User.fromJson(Map<String, dynamic> json) => User(
+        userId: json['user_id'] as int,
+        username: json['username'] as String? ?? '',
+        email: json['email'] as String? ?? '',
+      );
+}
+
+class Company {
+  final int companyId;
+  final String name;
+
+  Company({required this.companyId, required this.name});
+
+  factory Company.fromJson(Map<String, dynamic> json) => Company(
+        companyId: json['company_id'] as int,
+        name: json['name'] as String? ?? '',
+      );
+}
+
+class LoginResponse {
+  final String accessToken;
+  final String refreshToken;
+  final String sessionId;
+  final User user;
+  final Company? company;
+
+  LoginResponse({
+    required this.accessToken,
+    required this.refreshToken,
+    required this.sessionId,
+    required this.user,
+    this.company,
+  });
+
+  factory LoginResponse.fromJson(Map<String, dynamic> json) => LoginResponse(
+        accessToken: json['access_token'] as String,
+        refreshToken: json['refresh_token'] as String,
+        sessionId: json['session_id'] as String,
+        user: User.fromJson(json['user'] as Map<String, dynamic>),
+        company: json['company'] != null
+            ? Company.fromJson(json['company'] as Map<String, dynamic>)
+            : null,
+      );
+}
+
+class RegisterResponse {
+  final int userId;
+  final String username;
+  final String email;
+  final String message;
+
+  RegisterResponse({
+    required this.userId,
+    required this.username,
+    required this.email,
+    required this.message,
+  });
+
+  factory RegisterResponse.fromJson(Map<String, dynamic> json) =>
+      RegisterResponse(
+        userId: json['user_id'] as int,
+        username: json['username'] as String,
+        email: json['email'] as String,
+        message: json['message'] as String? ?? '',
+      );
+}
+
+class CompanyResponse {
+  final Company company;
+  CompanyResponse(this.company);
+  factory CompanyResponse.fromJson(Map<String, dynamic> json) =>
+      CompanyResponse(Company.fromJson(json));
+}

--- a/flutter_app/lib/features/auth/presentation/create_company_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/create_company_screen.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../controllers/auth_notifier.dart';
+import '../../../home_screen.dart';
+
+class CreateCompanyScreen extends ConsumerStatefulWidget {
+  const CreateCompanyScreen({super.key});
+
+  @override
+  ConsumerState<CreateCompanyScreen> createState() => _CreateCompanyScreenState();
+}
+
+class _CreateCompanyScreenState extends ConsumerState<CreateCompanyScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _emailController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(authNotifierProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create Company')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Company Name'),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(labelText: 'Email (optional)'),
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: state.isLoading
+                    ? null
+                    : () async {
+                        if (_formKey.currentState!.validate()) {
+                          final company = await ref
+                              .read(authNotifierProvider.notifier)
+                              .createCompany(
+                                name: _nameController.text,
+                                email: _emailController.text.isEmpty
+                                    ? null
+                                    : _emailController.text,
+                              );
+                          if (company != null && mounted) {
+                            Navigator.pushAndRemoveUntil(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (_) => const HomeScreen()),
+                              (route) => false,
+                            );
+                          } else if (mounted && state.error != null) {
+                            ScaffoldMessenger.of(context)
+                                .showSnackBar(SnackBar(content: Text(state.error!)));
+                          }
+                        }
+                      },
+                style: ElevatedButton.styleFrom(backgroundColor: Colors.red, foregroundColor: Colors.white),
+                child: state.isLoading
+                    ? const SizedBox(
+                        height: 16,
+                        width: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Create'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/features/auth/presentation/forgot_password_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/forgot_password_screen.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../controllers/auth_notifier.dart';
+import 'reset_password_screen.dart';
+
+class ForgotPasswordScreen extends ConsumerStatefulWidget {
+  const ForgotPasswordScreen({super.key});
+
+  @override
+  ConsumerState<ForgotPasswordScreen> createState() => _ForgotPasswordScreenState();
+}
+
+class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(authNotifierProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Forgot Password')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(labelText: 'Email'),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: state.isLoading
+                    ? null
+                    : () async {
+                        if (_formKey.currentState!.validate()) {
+                          final ok = await ref
+                              .read(authNotifierProvider.notifier)
+                              .forgotPassword(_emailController.text);
+                          if (ok && mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(
+                                    content: Text('Reset instructions sent')));
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (_) => const ResetPasswordScreen()),
+                            );
+                          } else if (mounted && state.error != null) {
+                            ScaffoldMessenger.of(context)
+                                .showSnackBar(SnackBar(content: Text(state.error!)));
+                          }
+                        }
+                      },
+                style: ElevatedButton.styleFrom(backgroundColor: Colors.red, foregroundColor: Colors.white),
+                child: state.isLoading
+                    ? const SizedBox(
+                        height: 16,
+                        width: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Submit'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/features/auth/presentation/login_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/login_screen.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../controllers/auth_notifier.dart';
+import '../../../home_screen.dart';
+import 'register_screen.dart';
+import 'forgot_password_screen.dart';
+import 'create_company_screen.dart';
+
+class LoginScreen extends ConsumerStatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  ConsumerState<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends ConsumerState<LoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(authNotifierProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(labelText: 'Email or Username'),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Password'),
+                obscureText: true,
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: state.isLoading
+                    ? null
+                    : () async {
+                        if (_formKey.currentState!.validate()) {
+                          final res = await ref.read(authNotifierProvider.notifier).login(
+                                email: _emailController.text,
+                                password: _passwordController.text,
+                              );
+                          if (res != null) {
+                            if (res.company == null) {
+                              if (!mounted) return;
+                              Navigator.pushReplacement(
+                                context,
+                                MaterialPageRoute(
+                                    builder: (_) => const CreateCompanyScreen()),
+                              );
+                            } else {
+                              if (!mounted) return;
+                              Navigator.pushReplacement(
+                                context,
+                                MaterialPageRoute(
+                                    builder: (_) => const HomeScreen()),
+                              );
+                            }
+                          } else if (mounted && state.error != null) {
+                            ScaffoldMessenger.of(context)
+                                .showSnackBar(SnackBar(content: Text(state.error!)));
+                          }
+                        }
+                      },
+                style: ElevatedButton.styleFrom(backgroundColor: Colors.red, foregroundColor: Colors.white),
+                child: state.isLoading
+                    ? const SizedBox(
+                        height: 16,
+                        width: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Login'),
+              ),
+              TextButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const RegisterScreen()),
+                  );
+                },
+                child: const Text('Register'),
+              ),
+              TextButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const ForgotPasswordScreen()),
+                  );
+                },
+                child: const Text('Forgot Password'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/features/auth/presentation/register_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/register_screen.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../controllers/auth_notifier.dart';
+
+class RegisterScreen extends ConsumerStatefulWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  ConsumerState<RegisterScreen> createState() => _RegisterScreenState();
+}
+
+class _RegisterScreenState extends ConsumerState<RegisterScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _usernameController = TextEditingController();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(authNotifierProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Register')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: _usernameController,
+                decoration: const InputDecoration(labelText: 'Username'),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(labelText: 'Email'),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Password'),
+                obscureText: true,
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: state.isLoading
+                    ? null
+                    : () async {
+                        if (_formKey.currentState!.validate()) {
+                          final res = await ref.read(authNotifierProvider.notifier).register(
+                                username: _usernameController.text,
+                                email: _emailController.text,
+                                password: _passwordController.text,
+                              );
+                          if (res != null && mounted) {
+                            Navigator.pop(context);
+                            ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text(res.message)));
+                          } else if (mounted && state.error != null) {
+                            ScaffoldMessenger.of(context)
+                                .showSnackBar(SnackBar(content: Text(state.error!)));
+                          }
+                        }
+                      },
+                style: ElevatedButton.styleFrom(backgroundColor: Colors.red, foregroundColor: Colors.white),
+                child: state.isLoading
+                    ? const SizedBox(
+                        height: 16,
+                        width: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Register'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/features/auth/presentation/reset_password_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/reset_password_screen.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../controllers/auth_notifier.dart';
+
+class ResetPasswordScreen extends ConsumerStatefulWidget {
+  const ResetPasswordScreen({super.key});
+
+  @override
+  ConsumerState<ResetPasswordScreen> createState() => _ResetPasswordScreenState();
+}
+
+class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _tokenController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(authNotifierProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Reset Password')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: _tokenController,
+                decoration: const InputDecoration(labelText: 'Token'),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'New Password'),
+                obscureText: true,
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: state.isLoading
+                    ? null
+                    : () async {
+                        if (_formKey.currentState!.validate()) {
+                          final ok = await ref
+                              .read(authNotifierProvider.notifier)
+                              .resetPassword(
+                                  _tokenController.text, _passwordController.text);
+                          if (ok && mounted) {
+                            Navigator.pop(context);
+                            ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('Password reset')));
+                          } else if (mounted && state.error != null) {
+                            ScaffoldMessenger.of(context)
+                                .showSnackBar(SnackBar(content: Text(state.error!)));
+                          }
+                        }
+                      },
+                style: ElevatedButton.styleFrom(backgroundColor: Colors.red, foregroundColor: Colors.white),
+                child: state.isLoading
+                    ? const SizedBox(
+                        height: 16,
+                        width: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Reset'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/lib/home_screen.dart
+++ b/flutter_app/lib/home_screen.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('Home')),
+    );
+  }
+}

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,125 +1,36 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-void main() {
-  runApp(const MyApp());
+import 'core/app_theme.dart';
+import 'features/auth/controllers/auth_notifier.dart';
+import 'features/auth/data/auth_repository.dart';
+import 'features/auth/presentation/login_screen.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await SharedPreferences.getInstance();
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost:8080/api/v1'));
+  runApp(
+    ProviderScope(
+      overrides: [
+        authRepositoryProvider.overrideWithValue(AuthRepository(dio, prefs)),
+      ],
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      title: 'EBS Lite',
+      theme: appTheme,
+      home: const LoginScreen(),
     );
   }
 }

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -34,6 +34,10 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  flutter_riverpod: ^2.5.1
+  dio: ^5.4.0
+  shared_preferences: ^2.2.2
+  uuid: ^3.0.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add Riverpod and networking dependencies
- implement auth repository and state notifier tied to Go backend endpoints
- create login, registration, password reset and company setup screens with theme

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format lib test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab01938fcc832c9ce2035725e743b9