### PR TITLE
Refine theming and auth screen UX

### DIFF
--- a/flutter_app/lib/core/app_theme.dart
+++ b/flutter_app/lib/core/app_theme.dart
@@ -1,29 +1,100 @@
 import 'package:flutter/material.dart';
 
+/// Base seed color used across both themes.
+const Color _seedRed = Color(0xFFC62828);
+
 /// Light theme definition used across the app.
 final ThemeData lightTheme = ThemeData(
-  colorScheme: const ColorScheme.light(
-    primary: Colors.black,
-    secondary: Colors.red,
-    surface: Colors.white,
+  colorScheme: ColorScheme.fromSeed(
+    seedColor: _seedRed,
+    brightness: Brightness.light,
+  ).copyWith(
+    background: Colors.white,
+    surface: Colors.grey.shade50,
+    onBackground: Colors.black,
+    onSurface: Colors.black,
   ),
   scaffoldBackgroundColor: Colors.white,
-  appBarTheme: const AppBarTheme(backgroundColor: Colors.black, foregroundColor: Colors.white),
-  floatingActionButtonTheme:
-      const FloatingActionButtonThemeData(backgroundColor: Colors.red, foregroundColor: Colors.white),
+  appBarTheme: const AppBarTheme(
+    backgroundColor: Colors.white,
+    foregroundColor: Colors.black,
+    elevation: 0,
+  ),
+  cardTheme: CardTheme(
+    color: Colors.grey.shade50,
+    elevation: 0,
+    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+  ),
+  inputDecorationTheme: InputDecorationTheme(
+    filled: true,
+    fillColor: Colors.grey.shade200,
+    border: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(12),
+      borderSide: BorderSide.none,
+    ),
+  ),
+  filledButtonTheme: FilledButtonThemeData(
+    style: FilledButton.styleFrom(
+      backgroundColor: _seedRed,
+      foregroundColor: Colors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+    ),
+  ),
+  checkboxTheme: CheckboxThemeData(
+    fillColor: MaterialStateProperty.resolveWith((states) {
+      if (states.contains(MaterialState.selected)) {
+        return _seedRed;
+      }
+      return Colors.grey;
+    }),
+  ),
   useMaterial3: true,
 );
 
 /// Dark theme counterpart
 final ThemeData darkTheme = ThemeData(
-  colorScheme: const ColorScheme.dark(
-    primary: Colors.white,
-    secondary: Colors.red,
-    surface: Colors.black,
+  colorScheme: ColorScheme.fromSeed(
+    seedColor: _seedRed,
+    brightness: Brightness.dark,
+  ).copyWith(
+    background: Colors.black,
+    surface: Colors.grey.shade900,
+    onBackground: Colors.white,
+    onSurface: Colors.white,
   ),
   scaffoldBackgroundColor: Colors.black,
-  appBarTheme: const AppBarTheme(backgroundColor: Colors.black, foregroundColor: Colors.white),
-  floatingActionButtonTheme:
-      const FloatingActionButtonThemeData(backgroundColor: Colors.red, foregroundColor: Colors.white),
+  appBarTheme: const AppBarTheme(
+    backgroundColor: Colors.black,
+    foregroundColor: Colors.white,
+    elevation: 0,
+  ),
+  cardTheme: CardTheme(
+    color: Colors.grey.shade900,
+    elevation: 0,
+    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+  ),
+  inputDecorationTheme: InputDecorationTheme(
+    filled: true,
+    fillColor: Colors.grey.shade800,
+    border: OutlineInputBorder(
+      borderRadius: BorderRadius.circular(12),
+      borderSide: BorderSide.none,
+    ),
+  ),
+  filledButtonTheme: FilledButtonThemeData(
+    style: FilledButton.styleFrom(
+      backgroundColor: _seedRed,
+      foregroundColor: Colors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+    ),
+  ),
+  checkboxTheme: CheckboxThemeData(
+    fillColor: MaterialStateProperty.resolveWith((states) {
+      if (states.contains(MaterialState.selected)) {
+        return _seedRed;
+      }
+      return Colors.grey.shade600;
+    }),
+  ),
   useMaterial3: true,
 );

--- a/flutter_app/lib/core/theme_notifier.dart
+++ b/flutter_app/lib/core/theme_notifier.dart
@@ -3,8 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Controls light and dark theme switching
 class ThemeNotifier extends StateNotifier<ThemeMode> {
-  ThemeNotifier() : super(ThemeMode.light);
+  ThemeNotifier() : super(ThemeMode.system);
 
+  /// Toggle between light and dark modes. Defaults to system brightness.
   void toggle() {
     state = state == ThemeMode.light ? ThemeMode.dark : ThemeMode.light;
   }

--- a/flutter_app/lib/features/auth/presentation/create_company_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/create_company_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../controllers/auth_notifier.dart';
 import '../../dashboard/presentation/dashboard_screen.dart';
+import '../../../core/theme_notifier.dart';
 
 class CreateCompanyScreen extends ConsumerStatefulWidget {
   const CreateCompanyScreen({super.key});
@@ -19,6 +20,23 @@ class _CreateCompanyScreenState extends ConsumerState<CreateCompanyScreen> {
 
   final _nameFocus = FocusNode();
   final _emailFocus = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    ref.listen(authNotifierProvider, (prev, next) {
+      if (next.error != null && mounted) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            SnackBar(
+              content: Text(next.error!),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+      }
+    });
+  }
 
   @override
   void dispose() {
@@ -72,20 +90,6 @@ class _CreateCompanyScreenState extends ConsumerState<CreateCompanyScreen> {
 
   @override
   Widget build(BuildContext context) {
-    // ✅ move listen into build
-    ref.listen(authNotifierProvider, (prev, next) {
-      if (next.error != null && mounted) {
-        ScaffoldMessenger.of(context)
-          ..hideCurrentSnackBar()
-          ..showSnackBar(
-            SnackBar(
-              content: Text(next.error!),
-              behavior: SnackBarBehavior.floating,
-            ),
-          );
-      }
-    });
-
     final state = ref.watch(authNotifierProvider);
     final theme = Theme.of(context);
     final media = MediaQuery.of(context);
@@ -100,6 +104,18 @@ class _CreateCompanyScreenState extends ConsumerState<CreateCompanyScreen> {
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Create Company'),
+          actions: [
+            IconButton(
+              tooltip: 'Toggle theme',
+              onPressed: () =>
+                  ref.read(themeNotifierProvider.notifier).toggle(),
+              icon: Icon(
+                theme.brightness == Brightness.dark
+                    ? Icons.light_mode
+                    : Icons.dark_mode,
+              ),
+            ),
+          ],
         ),
         body: SafeArea(
           child: Align(

--- a/flutter_app/lib/features/auth/presentation/forgot_password_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/forgot_password_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../controllers/auth_notifier.dart';
 import 'reset_password_screen.dart';
+import '../../../core/theme_notifier.dart';
 
 class ForgotPasswordScreen extends ConsumerStatefulWidget {
   const ForgotPasswordScreen({super.key});
@@ -16,6 +17,23 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
   final _formKey = GlobalKey<FormState>();
   final _emailController = TextEditingController();
   final _emailFocus = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    ref.listen(authNotifierProvider, (prev, next) {
+      if (next.error != null && mounted) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            SnackBar(
+              content: Text(next.error!),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+      }
+    });
+  }
 
   @override
   void dispose() {
@@ -66,20 +84,6 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
 
   @override
   Widget build(BuildContext context) {
-    // ✅ move listen into build
-    ref.listen(authNotifierProvider, (prev, next) {
-      if (next.error != null && mounted) {
-        ScaffoldMessenger.of(context)
-          ..hideCurrentSnackBar()
-          ..showSnackBar(
-            SnackBar(
-              content: Text(next.error!),
-              behavior: SnackBarBehavior.floating,
-            ),
-          );
-      }
-    });
-
     final state = ref.watch(authNotifierProvider);
     final theme = Theme.of(context);
     final media = MediaQuery.of(context);
@@ -94,6 +98,18 @@ class _ForgotPasswordScreenState extends ConsumerState<ForgotPasswordScreen> {
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Forgot Password'),
+          actions: [
+            IconButton(
+              tooltip: 'Toggle theme',
+              onPressed: () =>
+                  ref.read(themeNotifierProvider.notifier).toggle(),
+              icon: Icon(
+                theme.brightness == Brightness.dark
+                    ? Icons.light_mode
+                    : Icons.dark_mode,
+              ),
+            ),
+          ],
         ),
         body: SafeArea(
           child: Align(

--- a/flutter_app/lib/features/auth/presentation/login_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/login_screen.dart
@@ -6,6 +6,7 @@ import '../../dashboard/presentation/dashboard_screen.dart';
 import 'register_screen.dart';
 import 'forgot_password_screen.dart';
 import 'create_company_screen.dart';
+import '../../../core/theme_notifier.dart';
 
 class LoginScreen extends ConsumerStatefulWidget {
   const LoginScreen({super.key});
@@ -24,7 +25,24 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   final _passwordFocus = FocusNode();
 
   bool _obscure = true;
-  bool _rememberMe = true;
+  bool _rememberMe = false;
+
+  @override
+  void initState() {
+    super.initState();
+    ref.listen(authNotifierProvider, (prev, next) {
+      if (next.error != null && mounted) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            SnackBar(
+              content: Text(next.error!),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+      }
+    });
+  }
 
   @override
   void dispose() {
@@ -86,20 +104,6 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
 
   @override
   Widget build(BuildContext context) {
-    // ✅ Riverpod listener must be inside build (or use listenManual in initState)
-    ref.listen(authNotifierProvider, (prev, next) {
-      if (next.error != null && mounted) {
-        ScaffoldMessenger.of(context)
-          ..hideCurrentSnackBar()
-          ..showSnackBar(
-            SnackBar(
-              content: Text(next.error!),
-              behavior: SnackBarBehavior.floating,
-            ),
-          );
-      }
-    });
-
     final state = ref.watch(authNotifierProvider);
     final theme = Theme.of(context);
     final media = MediaQuery.of(context);
@@ -112,7 +116,21 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     return GestureDetector(
       onTap: () => FocusScope.of(context).unfocus(),
       child: Scaffold(
-        appBar: AppBar(title: const Text('Login')),
+        appBar: AppBar(
+          title: const Text('Login'),
+          actions: [
+            IconButton(
+              tooltip: 'Toggle theme',
+              onPressed: () =>
+                  ref.read(themeNotifierProvider.notifier).toggle(),
+              icon: Icon(
+                theme.brightness == Brightness.dark
+                    ? Icons.light_mode
+                    : Icons.dark_mode,
+              ),
+            ),
+          ],
+        ),
         body: SafeArea(
           child: Align(
             alignment: Alignment.topCenter,

--- a/flutter_app/lib/features/auth/presentation/register_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/register_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../controllers/auth_notifier.dart';
+import '../../../core/theme_notifier.dart';
 
 class RegisterScreen extends ConsumerStatefulWidget {
   const RegisterScreen({super.key});
@@ -25,7 +26,24 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
 
   bool _obscure = true;
   bool _obscureConfirm = true;
-  bool _agree = true;
+  bool _agree = false;
+
+  @override
+  void initState() {
+    super.initState();
+    ref.listen(authNotifierProvider, (prev, next) {
+      if (next.error != null && mounted) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            SnackBar(
+              content: Text(next.error!),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+      }
+    });
+  }
 
   @override
   void dispose() {
@@ -117,20 +135,6 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
 
   @override
   Widget build(BuildContext context) {
-    // ✅ move listen into build
-    ref.listen(authNotifierProvider, (prev, next) {
-      if (next.error != null && mounted) {
-        ScaffoldMessenger.of(context)
-          ..hideCurrentSnackBar()
-          ..showSnackBar(
-            SnackBar(
-              content: Text(next.error!),
-              behavior: SnackBarBehavior.floating,
-            ),
-          );
-      }
-    });
-
     final state = ref.watch(authNotifierProvider);
     final theme = Theme.of(context);
     final media = MediaQuery.of(context);
@@ -154,7 +158,21 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
     return GestureDetector(
       onTap: () => FocusScope.of(context).unfocus(),
       child: Scaffold(
-        appBar: AppBar(title: const Text('Register')),
+        appBar: AppBar(
+          title: const Text('Register'),
+          actions: [
+            IconButton(
+              tooltip: 'Toggle theme',
+              onPressed: () =>
+                  ref.read(themeNotifierProvider.notifier).toggle(),
+              icon: Icon(
+                theme.brightness == Brightness.dark
+                    ? Icons.light_mode
+                    : Icons.dark_mode,
+              ),
+            ),
+          ],
+        ),
         body: SafeArea(
           child: Align(
             alignment: Alignment.topCenter,

--- a/flutter_app/lib/features/auth/presentation/reset_password_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/reset_password_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../controllers/auth_notifier.dart';
+import '../../../core/theme_notifier.dart';
 
 class ResetPasswordScreen extends ConsumerStatefulWidget {
   const ResetPasswordScreen({super.key});
@@ -24,6 +25,23 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
 
   bool _obscure = true;
   bool _obscureConfirm = true;
+
+  @override
+  void initState() {
+    super.initState();
+    ref.listen(authNotifierProvider, (prev, next) {
+      if (next.error != null && mounted) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            SnackBar(
+              content: Text(next.error!),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+      }
+    });
+  }
 
   @override
   void dispose() {
@@ -94,20 +112,6 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
 
   @override
   Widget build(BuildContext context) {
-    // ✅ move listen into build
-    ref.listen(authNotifierProvider, (prev, next) {
-      if (next.error != null && mounted) {
-        ScaffoldMessenger.of(context)
-          ..hideCurrentSnackBar()
-          ..showSnackBar(
-            SnackBar(
-              content: Text(next.error!),
-              behavior: SnackBarBehavior.floating,
-            ),
-          );
-      }
-    });
-
     final state = ref.watch(authNotifierProvider);
     final theme = Theme.of(context);
     final media = MediaQuery.of(context);
@@ -131,7 +135,21 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
     return GestureDetector(
       onTap: () => FocusScope.of(context).unfocus(),
       child: Scaffold(
-        appBar: AppBar(title: const Text('Reset Password')),
+        appBar: AppBar(
+          title: const Text('Reset Password'),
+          actions: [
+            IconButton(
+              tooltip: 'Toggle theme',
+              onPressed: () =>
+                  ref.read(themeNotifierProvider.notifier).toggle(),
+              icon: Icon(
+                theme.brightness == Brightness.dark
+                    ? Icons.light_mode
+                    : Icons.dark_mode,
+              ),
+            ),
+          ],
+        ),
         body: SafeArea(
           child: Align(
             alignment: Alignment.topCenter,


### PR DESCRIPTION
## Summary
- Revamp light/dark themes using red, white, grey and black palette with consistent inputs, cards and buttons
- Default theme mode to system and expose toggle control on auth screens
- Clean up auth screens by registering error listeners once and polishing defaults

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4c31aa68832c910919cd484400d9