### PR TITLE
Use build-scope listener for login errors

### DIFF
--- a/flutter_app/lib/features/auth/presentation/login_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/login_screen.dart
@@ -28,23 +28,6 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   bool _rememberMe = false;
 
   @override
-  void initState() {
-    super.initState();
-    ref.listen(authNotifierProvider, (prev, next) {
-      if (next.error != null && mounted) {
-        ScaffoldMessenger.of(context)
-          ..hideCurrentSnackBar()
-          ..showSnackBar(
-            SnackBar(
-              content: Text(next.error!),
-              behavior: SnackBarBehavior.floating,
-            ),
-          );
-      }
-    });
-  }
-
-  @override
   void dispose() {
     _emailController.dispose();
     _passwordController.dispose();
@@ -104,6 +87,19 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen(authNotifierProvider, (prev, next) {
+      if (next.error != null && mounted) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            SnackBar(
+              content: Text(next.error!),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+      }
+    });
+
     final state = ref.watch(authNotifierProvider);
     final theme = Theme.of(context);
     final media = MediaQuery.of(context);


### PR DESCRIPTION
## Summary
- remove `ref.listen` from `initState`
- listen for `authNotifierProvider` at top of `build`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4f154228832c8ac1b44665d3a732