### PR TITLE
Use manual listener in reset password screen

### DIFF
--- a/flutter_app/lib/features/auth/presentation/reset_password_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/reset_password_screen.dart
@@ -26,10 +26,12 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
   bool _obscure = true;
   bool _obscureConfirm = true;
 
+  ProviderSubscription<AuthState>? _authSub;
+
   @override
   void initState() {
     super.initState();
-    ref.listen(authNotifierProvider, (prev, next) {
+    _authSub = ref.listenManual(authNotifierProvider, (prev, next) {
       if (next.error != null && mounted) {
         ScaffoldMessenger.of(context)
           ..hideCurrentSnackBar()
@@ -51,6 +53,7 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
     _tokenFocus.dispose();
     _passwordFocus.dispose();
     _confirmFocus.dispose();
+    _authSub?.close();
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- replace initState `ref.listen` with manual listener subscription
- cancel provider subscription during widget disposal

## Testing
- `dart format flutter_app/lib/features/auth/presentation/reset_password_screen.dart` *(command not found)*
- `flutter analyze lib/features/auth/presentation/reset_password_screen.dart` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab50a07324832c829b50b7e752d6aa