### PR TITLE
refactor: handle auth errors in build

### DIFF
--- a/flutter_app/lib/features/auth/presentation/create_company_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/create_company_screen.dart
@@ -22,23 +22,6 @@ class _CreateCompanyScreenState extends ConsumerState<CreateCompanyScreen> {
   final _emailFocus = FocusNode();
 
   @override
-  void initState() {
-    super.initState();
-    ref.listen(authNotifierProvider, (prev, next) {
-      if (next.error != null && mounted) {
-        ScaffoldMessenger.of(context)
-          ..hideCurrentSnackBar()
-          ..showSnackBar(
-            SnackBar(
-              content: Text(next.error!),
-              behavior: SnackBarBehavior.floating,
-            ),
-          );
-      }
-    });
-  }
-
-  @override
   void dispose() {
     _nameController.dispose();
     _emailController.dispose();
@@ -90,6 +73,18 @@ class _CreateCompanyScreenState extends ConsumerState<CreateCompanyScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen(authNotifierProvider, (prev, next) {
+      if (next.error != null && mounted) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            SnackBar(
+              content: Text(next.error!),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+      }
+    });
     final state = ref.watch(authNotifierProvider);
     final theme = Theme.of(context);
     final media = MediaQuery.of(context);


### PR DESCRIPTION
## Summary
- handle auth errors with ref.listen inside build and remove initState listener

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*


------
https://chatgpt.com/codex/tasks/task_e_68ab50b83dc8832c95c0346bae28ea6b