### PR TITLE
Move auth listener to build in register screen

### DIFF
--- a/flutter_app/lib/features/auth/presentation/register_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/register_screen.dart
@@ -29,23 +29,6 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
   bool _agree = false;
 
   @override
-  void initState() {
-    super.initState();
-    ref.listen(authNotifierProvider, (prev, next) {
-      if (next.error != null && mounted) {
-        ScaffoldMessenger.of(context)
-          ..hideCurrentSnackBar()
-          ..showSnackBar(
-            SnackBar(
-              content: Text(next.error!),
-              behavior: SnackBarBehavior.floating,
-            ),
-          );
-      }
-    });
-  }
-
-  @override
   void dispose() {
     _usernameController.dispose();
     _emailController.dispose();
@@ -135,6 +118,19 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen(authNotifierProvider, (prev, next) {
+      if (next.error != null && mounted) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            SnackBar(
+              content: Text(next.error!),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+      }
+    });
+
     final state = ref.watch(authNotifierProvider);
     final theme = Theme.of(context);
     final media = MediaQuery.of(context);


### PR DESCRIPTION
## Summary
- move auth error listener from initState to build in register screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab50ba2fcc832c88fcb6bfe9f2a8b3