### PR TITLE
Validate persisted tokens on app startup

### DIFF
--- a/flutter_app/lib/features/auth/controllers/auth_notifier.dart
+++ b/flutter_app/lib/features/auth/controllers/auth_notifier.dart
@@ -98,6 +98,10 @@ class AuthNotifier extends StateNotifier<AuthState> {
       return null;
     }
   }
+
+  void setAuth({required User user, Company? company}) {
+    state = state.copyWith(user: user, company: company);
+  }
 }
 
 final authNotifierProvider = StateNotifierProvider<AuthNotifier, AuthState>((ref) {

--- a/flutter_app/lib/features/auth/data/auth_repository.dart
+++ b/flutter_app/lib/features/auth/data/auth_repository.dart
@@ -10,8 +10,9 @@ class AuthRepository {
   final SharedPreferences _prefs;
 
   static const _deviceKey = 'device_id';
-  static const _accessTokenKey = 'access_token';
-  static const _refreshTokenKey = 'refresh_token';
+  static const accessTokenKey = 'access_token';
+  static const refreshTokenKey = 'refresh_token';
+  static const sessionIdKey = 'session_id';
 
   Future<String> _getDeviceId() async {
     var id = _prefs.getString(_deviceKey);
@@ -41,8 +42,9 @@ class AuthRepository {
     final response = await _dio.post('/auth/login', data: payload);
     final data =
         LoginResponse.fromJson(response.data['data'] as Map<String, dynamic>);
-    await _prefs.setString(_accessTokenKey, data.accessToken);
-    await _prefs.setString(_refreshTokenKey, data.refreshToken);
+    await _prefs.setString(accessTokenKey, data.accessToken);
+    await _prefs.setString(refreshTokenKey, data.refreshToken);
+    await _prefs.setString(sessionIdKey, data.sessionId);
     return data;
   }
 
@@ -72,11 +74,22 @@ class AuthRepository {
   }
 
   Future<Company> createCompany({required String name, String? email}) async {
-    final token = _prefs.getString(_accessTokenKey);
+    final token = _prefs.getString(accessTokenKey);
     final response = await _dio.post('/companies',
         data: {'name': name, if (email != null) 'email': email},
         options: Options(headers: {'Authorization': 'Bearer $token'}));
     return Company.fromJson(
         response.data['data'] as Map<String, dynamic>);
+  }
+
+  Future<MeResponse> me() async {
+    final token = _prefs.getString(accessTokenKey);
+    final response = await _dio.get(
+      '/auth/me',
+      options: Options(headers: {'Authorization': 'Bearer $token'}),
+    );
+    return MeResponse.fromJson(
+      response.data['data'] as Map<String, dynamic>,
+    );
   }
 }

--- a/flutter_app/lib/features/auth/data/models.dart
+++ b/flutter_app/lib/features/auth/data/models.dart
@@ -78,3 +78,17 @@ class CompanyResponse {
   factory CompanyResponse.fromJson(Map<String, dynamic> json) =>
       CompanyResponse(Company.fromJson(json));
 }
+
+class MeResponse {
+  final User user;
+  final Company? company;
+
+  MeResponse({required this.user, this.company});
+
+  factory MeResponse.fromJson(Map<String, dynamic> json) => MeResponse(
+        user: User.fromJson(json['user'] as Map<String, dynamic>),
+        company: json['company'] != null
+            ? Company.fromJson(json['company'] as Map<String, dynamic>)
+            : null,
+      );
+}

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -8,34 +8,73 @@ import 'core/app_theme.dart';
 import 'features/auth/controllers/auth_notifier.dart';
 import 'features/auth/data/auth_repository.dart';
 import 'features/auth/presentation/login_screen.dart';
+import 'features/auth/data/models.dart';
+import 'features/dashboard/presentation/dashboard_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final prefs = await SharedPreferences.getInstance();
   final dio = Dio(BaseOptions(baseUrl: 'http://192.168.100.128:8080/api/v1'));
+  final authRepo = AuthRepository(dio, prefs);
+  User? user;
+  Company? company;
+  final accessToken = prefs.getString(AuthRepository.accessTokenKey);
+  final refreshToken = prefs.getString(AuthRepository.refreshTokenKey);
+  final sessionId = prefs.getString(AuthRepository.sessionIdKey);
+  if (accessToken != null && refreshToken != null && sessionId != null) {
+    try {
+      final res = await authRepo.me();
+      user = res.user;
+      company = res.company;
+    } catch (_) {
+      await prefs.remove(AuthRepository.accessTokenKey);
+      await prefs.remove(AuthRepository.refreshTokenKey);
+      await prefs.remove(AuthRepository.sessionIdKey);
+    }
+  }
   runApp(
     ProviderScope(
       overrides: [
-        authRepositoryProvider.overrideWithValue(AuthRepository(dio, prefs)),
+        authRepositoryProvider.overrideWithValue(authRepo),
       ],
-      child: const MyApp(),
+      child: MyApp(initialUser: user, initialCompany: company),
     ),
   );
 }
 
-class MyApp extends ConsumerWidget {
-  const MyApp({super.key});
+class MyApp extends ConsumerStatefulWidget {
+  const MyApp({super.key, this.initialUser, this.initialCompany});
+  final User? initialUser;
+  final Company? initialCompany;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends ConsumerState<MyApp> {
+  @override
+  void initState() {
+    super.initState();
+    if (widget.initialUser != null) {
+      ref
+          .read(authNotifierProvider.notifier)
+          .setAuth(user: widget.initialUser!, company: widget.initialCompany);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final mode = ref.watch(themeNotifierProvider);
+    final home = widget.initialUser != null
+        ? const DashboardScreen()
+        : const LoginScreen();
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'EBS Lite',
       theme: lightTheme,
       darkTheme: darkTheme,
       themeMode: mode,
-      home: const LoginScreen(),
+      home: home,
     );
   }
 }


### PR DESCRIPTION
## Summary
- Load auth tokens from `SharedPreferences` before rendering the app
- Validate tokens with `/auth/me` and store user/company in `AuthNotifier`
- Redirect to `DashboardScreen` when tokens are valid, otherwise clear tokens

## Testing
- `dart format lib/main.dart lib/features/auth/data/auth_repository.dart lib/features/auth/data/models.dart lib/features/auth/controllers/auth_notifier.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7c506774832cbea2e13e8ae4d85b