### PR TITLE
feat: add dio client with auth refresh

### DIFF
--- a/flutter_app/lib/core/api_client.dart
+++ b/flutter_app/lib/core/api_client.dart
@@ -1,0 +1,68 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../features/auth/data/auth_repository.dart';
+
+class ApiClient {
+  ApiClient(this._prefs, {String baseUrl = 'http://192.168.100.128:8080/api/v1'})
+      : dio = Dio(BaseOptions(baseUrl: baseUrl)) {
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          final token = _prefs.getString(AuthRepository.accessTokenKey);
+          if (token != null) {
+            options.headers['Authorization'] = 'Bearer $token';
+          }
+          handler.next(options);
+        },
+        onError: (error, handler) async {
+          if (error.response?.statusCode == 401) {
+            final refreshToken =
+                _prefs.getString(AuthRepository.refreshTokenKey);
+            if (refreshToken != null) {
+              try {
+                final refreshDio = Dio(BaseOptions(baseUrl: dio.options.baseUrl));
+                final res = await refreshDio.post(
+                  '/auth/refresh-token',
+                  data: {'refresh_token': refreshToken},
+                );
+                final data = res.data['data'] as Map<String, dynamic>;
+                final newAccess = data['access_token'] as String;
+                final newRefresh = data['refresh_token'] as String;
+                await _prefs.setString(
+                    AuthRepository.accessTokenKey, newAccess);
+                await _prefs.setString(
+                    AuthRepository.refreshTokenKey, newRefresh);
+                final sessionId = data['session_id'] as String?;
+                if (sessionId != null) {
+                  await _prefs.setString(
+                      AuthRepository.sessionIdKey, sessionId);
+                }
+                final reqOptions = error.requestOptions;
+                reqOptions.headers['Authorization'] = 'Bearer $newAccess';
+                final cloneReq = await dio.fetch(reqOptions);
+                return handler.resolve(cloneReq);
+              } catch (e) {
+                // If refreshing fails, forward the original error
+              }
+            }
+          }
+          handler.next(error);
+        },
+      ),
+    );
+  }
+
+  final SharedPreferences _prefs;
+  final Dio dio;
+}
+
+// Providers for dependency injection
+final dioProvider = Provider<Dio>((ref) {
+  throw UnimplementedError();
+});
+
+final sharedPreferencesProvider = Provider<SharedPreferences>((ref) {
+  throw UnimplementedError();
+});

--- a/flutter_app/lib/features/auth/controllers/auth_notifier.dart
+++ b/flutter_app/lib/features/auth/controllers/auth_notifier.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../data/auth_repository.dart';
 import '../data/models.dart';
+import '../../../core/api_client.dart';
 
 class AuthState {
   final bool isLoading;
@@ -110,5 +111,7 @@ final authNotifierProvider = StateNotifierProvider<AuthNotifier, AuthState>((ref
 });
 
 final authRepositoryProvider = Provider<AuthRepository>((ref) {
-  throw UnimplementedError();
+  final dio = ref.watch(dioProvider);
+  final prefs = ref.watch(sharedPreferencesProvider);
+  return AuthRepository(dio, prefs);
 });

--- a/flutter_app/lib/features/auth/data/auth_repository.dart
+++ b/flutter_app/lib/features/auth/data/auth_repository.dart
@@ -74,20 +74,14 @@ class AuthRepository {
   }
 
   Future<Company> createCompany({required String name, String? email}) async {
-    final token = _prefs.getString(accessTokenKey);
     final response = await _dio.post('/companies',
-        data: {'name': name, if (email != null) 'email': email},
-        options: Options(headers: {'Authorization': 'Bearer $token'}));
+        data: {'name': name, if (email != null) 'email': email});
     return Company.fromJson(
         response.data['data'] as Map<String, dynamic>);
   }
 
   Future<MeResponse> me() async {
-    final token = _prefs.getString(accessTokenKey);
-    final response = await _dio.get(
-      '/auth/me',
-      options: Options(headers: {'Authorization': 'Bearer $token'}),
-    );
+    final response = await _dio.get('/auth/me');
     return MeResponse.fromJson(
       response.data['data'] as Map<String, dynamic>,
     );

--- a/flutter_app/lib/features/dashboard/data/dashboard_repository.dart
+++ b/flutter_app/lib/features/dashboard/data/dashboard_repository.dart
@@ -1,0 +1,19 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/api_client.dart';
+
+class DashboardRepository {
+  DashboardRepository(this._dio);
+  final Dio _dio;
+
+  // Example placeholder method
+  Future<Response<dynamic>> ping() {
+    return _dio.get('/dashboard/ping');
+  }
+}
+
+final dashboardRepositoryProvider = Provider<DashboardRepository>((ref) {
+  final dio = ref.watch(dioProvider);
+  return DashboardRepository(dio);
+});

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,10 +1,10 @@
-import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'core/theme_notifier.dart';
 import 'core/app_theme.dart';
+import 'core/api_client.dart';
 import 'features/auth/controllers/auth_notifier.dart';
 import 'features/auth/data/auth_repository.dart';
 import 'features/auth/presentation/login_screen.dart';
@@ -14,8 +14,8 @@ import 'features/dashboard/presentation/dashboard_screen.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final prefs = await SharedPreferences.getInstance();
-  final dio = Dio(BaseOptions(baseUrl: 'http://192.168.100.128:8080/api/v1'));
-  final authRepo = AuthRepository(dio, prefs);
+  final apiClient = ApiClient(prefs);
+  final authRepo = AuthRepository(apiClient.dio, prefs);
   User? user;
   Company? company;
   final accessToken = prefs.getString(AuthRepository.accessTokenKey);
@@ -35,7 +35,8 @@ void main() async {
   runApp(
     ProviderScope(
       overrides: [
-        authRepositoryProvider.overrideWithValue(authRepo),
+        dioProvider.overrideWithValue(apiClient.dio),
+        sharedPreferencesProvider.overrideWithValue(prefs),
       ],
       child: MyApp(initialUser: user, initialCompany: company),
     ),

--- a/flutter_app/test/login_screen_test.dart
+++ b/flutter_app/test/login_screen_test.dart
@@ -31,6 +31,11 @@ class _FakeAuthRepository implements AuthRepository {
   Future<Company> createCompany({required String name, String? email}) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<MeResponse> me() {
+    throw UnimplementedError();
+  }
 }
 
 void main() {


### PR DESCRIPTION
## Summary
- add ApiClient wrapping Dio with auth header and token refresh interceptors
- inject configured Dio via Riverpod providers for repositories
- stub DashboardRepository and update tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7da4abdc832cb3dabb409eb98040