### PR TITLE
feat: surface company name in dashboard

### DIFF
--- a/flutter_app/lib/features/dashboard/presentation/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/presentation/dashboard_screen.dart
@@ -7,6 +7,7 @@ import 'widgets/dashboard_content.dart';
 import 'widgets/dashboard_header.dart';
 import 'widgets/dashboard_sidebar.dart';
 import 'widgets/quick_action_button.dart';
+import '../../auth/controllers/auth_notifier.dart';
 
 class DashboardScreen extends ConsumerStatefulWidget {
   const DashboardScreen({super.key});
@@ -47,6 +48,9 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
     final media = MediaQuery.of(context);
     final width = media.size.width;
 
+    final authState = ref.watch(authNotifierProvider);
+    final companyName = authState.company?.name ?? 'Company';
+
     final isWide = width >= 1000; // rail for desktop/tablet, drawer for phones
     final railExtended = width >= 1300;
 
@@ -68,7 +72,7 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
               behavior: SnackBarBehavior.floating,
             ));
         },
-        companyName: 'Company',
+        companyName: companyName,
         isOnline: true,
       ),
       drawer: isWide

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -18,6 +20,14 @@ void main() async {
   final authRepo = AuthRepository(apiClient.dio, prefs);
   User? user;
   Company? company;
+  final storedCompany = prefs.getString(AuthRepository.companyKey);
+  if (storedCompany != null) {
+    try {
+      company = Company.fromJson(jsonDecode(storedCompany) as Map<String, dynamic>);
+    } catch (_) {
+      await prefs.remove(AuthRepository.companyKey);
+    }
+  }
   final accessToken = prefs.getString(AuthRepository.accessTokenKey);
   final refreshToken = prefs.getString(AuthRepository.refreshTokenKey);
   final sessionId = prefs.getString(AuthRepository.sessionIdKey);


### PR DESCRIPTION
## Summary
- persist company details in SharedPreferences via AuthRepository
- read company name from authNotifierProvider in dashboard header
- load stored company on app startup

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ac82e11634832c92b18a0d02c9378b