### PR TITLE
Add dashboard data models, repository and notifier

### DIFF
--- a/flutter_app/lib/features/dashboard/controllers/dashboard_notifier.dart
+++ b/flutter_app/lib/features/dashboard/controllers/dashboard_notifier.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/dashboard_repository.dart';
+import '../data/models.dart';
+
+class DashboardState {
+  final DashboardMetrics? metrics;
+  final QuickActionCounts? quickActions;
+  final bool isLoading;
+  final String? error;
+
+  const DashboardState({
+    this.metrics,
+    this.quickActions,
+    this.isLoading = false,
+    this.error,
+  });
+
+  DashboardState copyWith({
+    DashboardMetrics? metrics,
+    QuickActionCounts? quickActions,
+    bool? isLoading,
+    String? error,
+  }) {
+    return DashboardState(
+      metrics: metrics ?? this.metrics,
+      quickActions: quickActions ?? this.quickActions,
+      isLoading: isLoading ?? this.isLoading,
+      error: error,
+    );
+  }
+}
+
+class DashboardNotifier extends StateNotifier<DashboardState> {
+  DashboardNotifier(this._repository) : super(const DashboardState());
+
+  final DashboardRepository _repository;
+
+  Future<void> load() async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final metrics = await _repository.getMetrics();
+      final actions = await _repository.getQuickActions();
+      state = state.copyWith(
+        isLoading: false,
+        metrics: metrics,
+        quickActions: actions,
+      );
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+}
+
+final dashboardNotifierProvider =
+    StateNotifierProvider<DashboardNotifier, DashboardState>((ref) {
+  final repo = ref.watch(dashboardRepositoryProvider);
+  final notifier = DashboardNotifier(repo);
+  notifier.load();
+  return notifier;
+});

--- a/flutter_app/lib/features/dashboard/data/dashboard_repository.dart
+++ b/flutter_app/lib/features/dashboard/data/dashboard_repository.dart
@@ -1,19 +1,44 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../core/api_client.dart';
+import '../../auth/data/auth_repository.dart';
+import 'models.dart';
 
 class DashboardRepository {
-  DashboardRepository(this._dio);
+  DashboardRepository(this._dio, this._prefs);
   final Dio _dio;
+  final SharedPreferences _prefs;
 
-  // Example placeholder method
-  Future<Response<dynamic>> ping() {
-    return _dio.get('/dashboard/ping');
+  Map<String, String> _authHeader() {
+    final token = _prefs.getString(AuthRepository.accessTokenKey);
+    return {
+      if (token != null) 'Authorization': 'Bearer $token',
+    };
+  }
+
+  Future<DashboardMetrics> getMetrics() async {
+    final res = await _dio.get(
+      '/dashboard/metrics',
+      options: Options(headers: _authHeader()),
+    );
+    return DashboardMetrics.fromJson(
+        res.data['data'] as Map<String, dynamic>);
+  }
+
+  Future<QuickActionCounts> getQuickActions() async {
+    final res = await _dio.get(
+      '/dashboard/quick-actions',
+      options: Options(headers: _authHeader()),
+    );
+    return QuickActionCounts.fromJson(
+        res.data['data'] as Map<String, dynamic>);
   }
 }
 
 final dashboardRepositoryProvider = Provider<DashboardRepository>((ref) {
   final dio = ref.watch(dioProvider);
-  return DashboardRepository(dio);
+  final prefs = ref.watch(sharedPreferencesProvider);
+  return DashboardRepository(dio, prefs);
 });

--- a/flutter_app/lib/features/dashboard/data/models.dart
+++ b/flutter_app/lib/features/dashboard/data/models.dart
@@ -1,0 +1,41 @@
+class DashboardMetrics {
+  final double creditOutstanding;
+  final double inventoryValue;
+  final double todaySales;
+  final double dailyCashSummary;
+
+  DashboardMetrics({
+    required this.creditOutstanding,
+    required this.inventoryValue,
+    required this.todaySales,
+    required this.dailyCashSummary,
+  });
+
+  factory DashboardMetrics.fromJson(Map<String, dynamic> json) => DashboardMetrics(
+        creditOutstanding: (json['credit_outstanding'] as num?)?.toDouble() ?? 0,
+        inventoryValue: (json['inventory_value'] as num?)?.toDouble() ?? 0,
+        todaySales: (json['today_sales'] as num?)?.toDouble() ?? 0,
+        dailyCashSummary: (json['daily_cash_summary'] as num?)?.toDouble() ?? 0,
+      );
+}
+
+class QuickActionCounts {
+  final int sales;
+  final int purchases;
+  final int collections;
+  final int expenses;
+
+  QuickActionCounts({
+    required this.sales,
+    required this.purchases,
+    required this.collections,
+    required this.expenses,
+  });
+
+  factory QuickActionCounts.fromJson(Map<String, dynamic> json) => QuickActionCounts(
+        sales: json['sales'] as int? ?? 0,
+        purchases: json['purchases'] as int? ?? 0,
+        collections: json['collections'] as int? ?? 0,
+        expenses: json['expenses'] as int? ?? 0,
+      );
+}

--- a/flutter_app/lib/features/dashboard/presentation/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/presentation/dashboard_screen.dart
@@ -8,6 +8,7 @@ import 'widgets/dashboard_header.dart';
 import 'widgets/dashboard_sidebar.dart';
 import 'widgets/quick_action_button.dart';
 import '../../auth/controllers/auth_notifier.dart';
+import '../controllers/dashboard_notifier.dart';
 
 class DashboardScreen extends ConsumerStatefulWidget {
   const DashboardScreen({super.key});
@@ -50,6 +51,8 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
 
     final authState = ref.watch(authNotifierProvider);
     final companyName = authState.company?.name ?? 'Company';
+    final dashboardState = ref.watch(dashboardNotifierProvider);
+    final quickCounts = dashboardState.quickActions;
 
     final isWide = width >= 1000; // rail for desktop/tablet, drawer for phones
     final railExtended = width >= 1300;
@@ -122,11 +125,19 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
         ],
       ),
       floatingActionButton: QuickActionButton(
-        actions: const [
-          QuickAction(icon: Icons.point_of_sale_rounded, label: 'Sale'),
-          QuickAction(icon: Icons.shopping_cart_rounded, label: 'Purchase'),
-          QuickAction(icon: Icons.payments_rounded, label: 'Collection'),
-          QuickAction(icon: Icons.money_off_rounded, label: 'Expense'),
+        actions: [
+          QuickAction(
+              icon: Icons.point_of_sale_rounded,
+              label: 'Sale (${quickCounts?.sales ?? 0})'),
+          QuickAction(
+              icon: Icons.shopping_cart_rounded,
+              label: 'Purchase (${quickCounts?.purchases ?? 0})'),
+          QuickAction(
+              icon: Icons.payments_rounded,
+              label: 'Collection (${quickCounts?.collections ?? 0})'),
+          QuickAction(
+              icon: Icons.money_off_rounded,
+              label: 'Expense (${quickCounts?.expenses ?? 0})'),
         ],
         onOpenChanged: (open) {
           // Example: dim app bar or log analytics here.

--- a/flutter_app/lib/features/dashboard/presentation/widgets/dashboard_content.dart
+++ b/flutter_app/lib/features/dashboard/presentation/widgets/dashboard_content.dart
@@ -1,13 +1,17 @@
 // lib/dashboard/presentation/dashboard_content.dart
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../controllers/dashboard_notifier.dart';
 import 'stat_card.dart';
 
-class DashboardContent extends StatelessWidget {
+class DashboardContent extends ConsumerWidget {
   const DashboardContent({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(dashboardNotifierProvider);
+    final metrics = state.metrics;
     final size = MediaQuery.of(context).size;
     final shortest = size.shortestSide;
 
@@ -32,32 +36,32 @@ class DashboardContent extends StatelessWidget {
                 mainAxisSpacing: 16,
                 childAspectRatio: constraints.maxWidth < 600 ? 1.2 : 1.4,
               ),
-              children: const [
+              children: [
                 StatCard(
                   icon: Icons.credit_card_rounded,
                   title: 'Total Credit Outstanding',
-                  value: '0',
+                  value: '${metrics?.creditOutstanding ?? 0}',
                   subtitle: 'All customers',
                   color: Colors.indigo,
                 ),
                 StatCard(
                   icon: Icons.inventory_2_rounded,
                   title: 'Total Inventory Value',
-                  value: '0',
+                  value: '${metrics?.inventoryValue ?? 0}',
                   subtitle: 'Across warehouses',
                   color: Colors.teal,
                 ),
                 StatCard(
                   icon: Icons.swap_horiz_rounded,
                   title: "Today's Sales & Purchases",
-                  value: '0',
+                  value: '${metrics?.todaySales ?? 0}',
                   subtitle: 'Net transactions',
                   color: Colors.orange,
                 ),
                 StatCard(
                   icon: Icons.attach_money_rounded,
                   title: 'Daily Cash Summary',
-                  value: '0',
+                  value: '${metrics?.dailyCashSummary ?? 0}',
                   subtitle: 'Cash flow',
                   color: Colors.green,
                 ),


### PR DESCRIPTION
## Summary
- model dashboard metrics and quick-action counts
- implement dashboard repository with auth header support
- add dashboard notifier and wire up dashboard widgets

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac83e72310832cb01e4d869447984f