### PR TITLE
feat: handle new user response

### DIFF
--- a/flutter_app/lib/features/auth/data/auth_repository.dart
+++ b/flutter_app/lib/features/auth/data/auth_repository.dart
@@ -102,22 +102,34 @@ class AuthRepository {
     return company;
   }
 
-  Future<MeResponse> me() async {
+  Future<UserResponse> me() async {
     final response = await _dio.get('/auth/me');
-    final data = MeResponse.fromJson(
-      response.data['data'] as Map<String, dynamic>,
-    );
-    if (data.company != null) {
+    final user =
+        UserResponse.fromJson(response.data['data'] as Map<String, dynamic>);
+    Company? company;
+    if (user.companyId != null) {
+      final companiesRes = await _dio.get('/companies');
+      final list = companiesRes.data['data'] as List<dynamic>;
+      try {
+        final companyJson = list
+            .cast<Map<String, dynamic>>()
+            .firstWhere((c) => c['company_id'] == user.companyId);
+        company = Company.fromJson(companyJson);
+      } catch (_) {
+        company = null;
+      }
+    }
+    if (company != null) {
       await _prefs.setString(
         companyKey,
         jsonEncode({
-          'company_id': data.company!.companyId,
-          'name': data.company!.name,
+          'company_id': company.companyId,
+          'name': company.name,
         }),
       );
     } else {
       await _prefs.remove(companyKey);
     }
-    return data;
+    return user;
   }
 }

--- a/flutter_app/lib/features/auth/data/models.dart
+++ b/flutter_app/lib/features/auth/data/models.dart
@@ -24,6 +24,70 @@ class Company {
       );
 }
 
+class UserResponse {
+  final int userId;
+  final int? companyId;
+  final int? locationId;
+  final int? roleId;
+  final String username;
+  final String email;
+  final String? firstName;
+  final String? lastName;
+  final String? phone;
+  final bool isActive;
+  final bool isLocked;
+  final String? preferredLanguage;
+  final String? secondaryLanguage;
+  final DateTime? lastLogin;
+  final List<String>? permissions;
+  final Map<String, String>? preferences;
+
+  UserResponse({
+    required this.userId,
+    this.companyId,
+    this.locationId,
+    this.roleId,
+    required this.username,
+    required this.email,
+    this.firstName,
+    this.lastName,
+    this.phone,
+    this.isActive = true,
+    this.isLocked = false,
+    this.preferredLanguage,
+    this.secondaryLanguage,
+    this.lastLogin,
+    this.permissions,
+    this.preferences,
+  });
+
+  factory UserResponse.fromJson(Map<String, dynamic> json) => UserResponse(
+        userId: json['user_id'] as int,
+        companyId: json['company_id'] as int?,
+        locationId: json['location_id'] as int?,
+        roleId: json['role_id'] as int?,
+        username: json['username'] as String? ?? '',
+        email: json['email'] as String? ?? '',
+        firstName: json['first_name'] as String?,
+        lastName: json['last_name'] as String?,
+        phone: json['phone'] as String?,
+        isActive: json['is_active'] as bool? ?? true,
+        isLocked: json['is_locked'] as bool? ?? false,
+        preferredLanguage: json['preferred_language'] as String?,
+        secondaryLanguage: json['secondary_language'] as String?,
+        lastLogin: json['last_login'] != null
+            ? DateTime.tryParse(json['last_login'] as String)
+            : null,
+        permissions: (json['permissions'] as List?)
+            ?.map((e) => e.toString())
+            .toList(),
+        preferences: (json['preferences'] as Map<String, dynamic>?)
+            ?.map((k, v) => MapEntry(k, v.toString())),
+      );
+
+  User toUser() => User(userId: userId, username: username, email: email);
+}
+
 class LoginResponse {
   final String accessToken;
   final String refreshToken;
@@ -77,18 +141,4 @@ class CompanyResponse {
   CompanyResponse(this.company);
   factory CompanyResponse.fromJson(Map<String, dynamic> json) =>
       CompanyResponse(Company.fromJson(json));
-}
-
-class MeResponse {
-  final User user;
-  final Company? company;
-
-  MeResponse({required this.user, this.company});
-
-  factory MeResponse.fromJson(Map<String, dynamic> json) => MeResponse(
-        user: User.fromJson(json['user'] as Map<String, dynamic>),
-        company: json['company'] != null
-            ? Company.fromJson(json['company'] as Map<String, dynamic>)
-            : null,
-      );
 }

--- a/flutter_app/test/login_screen_test.dart
+++ b/flutter_app/test/login_screen_test.dart
@@ -33,7 +33,7 @@ class _FakeAuthRepository implements AuthRepository {
   }
 
   @override
-  Future<MeResponse> me() {
+  Future<UserResponse> me() {
     throw UnimplementedError();
   }
 }


### PR DESCRIPTION
## Summary
- add `UserResponse` model for new backend format
- fetch company details in `me` using `company_id` and persist selection
- update startup flow to parse `UserResponse` and only clear tokens on 401

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac89690b1c832c8f1f278edc7e3274