### PR TITLE
feat: add location management and sidebar selection

### DIFF
--- a/flutter_app/lib/features/auth/presentation/login_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/login_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../controllers/auth_notifier.dart';
 import '../../dashboard/presentation/dashboard_screen.dart';
+import '../../dashboard/controllers/location_notifier.dart';
 import 'register_screen.dart';
 import 'forgot_password_screen.dart';
 import 'create_company_screen.dart';
@@ -77,6 +78,9 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           MaterialPageRoute(builder: (_) => const CreateCompanyScreen()),
         );
       } else {
+        await ref
+            .read(locationNotifierProvider.notifier)
+            .load(res.company!.companyId);
         Navigator.of(context).pushReplacement(
           MaterialPageRoute(builder: (_) => const DashboardScreen()),
         );

--- a/flutter_app/lib/features/dashboard/controllers/location_notifier.dart
+++ b/flutter_app/lib/features/dashboard/controllers/location_notifier.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../data/location_repository.dart';
+import '../data/models.dart';
+import '../../../core/api_client.dart';
+
+class LocationState {
+  final List<Location> locations;
+  final Location? selected;
+  final bool isLoading;
+  final String? error;
+
+  const LocationState({
+    this.locations = const [],
+    this.selected,
+    this.isLoading = false,
+    this.error,
+  });
+
+  LocationState copyWith({
+    List<Location>? locations,
+    Location? selected,
+    bool? isLoading,
+    String? error,
+  }) {
+    return LocationState(
+      locations: locations ?? this.locations,
+      selected: selected ?? this.selected,
+      isLoading: isLoading ?? this.isLoading,
+      error: error,
+    );
+  }
+}
+
+class LocationNotifier extends StateNotifier<LocationState> {
+  LocationNotifier(this._repository, this._prefs)
+      : super(const LocationState());
+
+  static const selectedLocationKey = 'selected_location_id';
+
+  final LocationRepository _repository;
+  final SharedPreferences _prefs;
+
+  Future<void> load(int companyId) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final list = await _repository.fetchLocations(companyId);
+      Location? selected;
+      final stored = _prefs.getInt(selectedLocationKey);
+      if (stored != null) {
+        try {
+          selected =
+              list.firstWhere((l) => l.locationId == stored);
+        } catch (_) {
+          selected = null;
+        }
+      }
+      state = state.copyWith(
+        isLoading: false,
+        locations: list,
+        selected: selected ?? (list.isNotEmpty ? list.first : null),
+      );
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+
+  Future<void> select(Location location) async {
+    state = state.copyWith(selected: location);
+    await _prefs.setInt(selectedLocationKey, location.locationId);
+  }
+}
+
+final locationNotifierProvider =
+    StateNotifierProvider<LocationNotifier, LocationState>((ref) {
+  final repo = ref.watch(locationRepositoryProvider);
+  final prefs = ref.watch(sharedPreferencesProvider);
+  return LocationNotifier(repo, prefs);
+});

--- a/flutter_app/lib/features/dashboard/data/location_repository.dart
+++ b/flutter_app/lib/features/dashboard/data/location_repository.dart
@@ -1,0 +1,39 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../core/api_client.dart';
+import '../../auth/data/auth_repository.dart';
+import 'models.dart';
+
+class LocationRepository {
+  LocationRepository(this._dio, this._prefs);
+
+  final Dio _dio;
+  final SharedPreferences _prefs;
+
+  Map<String, String> _authHeader() {
+    final token = _prefs.getString(AuthRepository.accessTokenKey);
+    return {
+      if (token != null) 'Authorization': 'Bearer $token',
+    };
+  }
+
+  Future<List<Location>> fetchLocations(int companyId) async {
+    final res = await _dio.get(
+      '/locations',
+      queryParameters: {'company_id': companyId},
+      options: Options(headers: _authHeader()),
+    );
+    final data = res.data['data'] as List<dynamic>;
+    return data
+        .map((e) => Location.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+}
+
+final locationRepositoryProvider = Provider<LocationRepository>((ref) {
+  final dio = ref.watch(dioProvider);
+  final prefs = ref.watch(sharedPreferencesProvider);
+  return LocationRepository(dio, prefs);
+});

--- a/flutter_app/lib/features/dashboard/data/models.dart
+++ b/flutter_app/lib/features/dashboard/data/models.dart
@@ -39,3 +39,15 @@ class QuickActionCounts {
         expenses: json['expenses'] as int? ?? 0,
       );
 }
+
+class Location {
+  final int locationId;
+  final String name;
+
+  Location({required this.locationId, required this.name});
+
+  factory Location.fromJson(Map<String, dynamic> json) => Location(
+        locationId: json['location_id'] as int,
+        name: json['name'] as String? ?? '',
+      );
+}

--- a/flutter_app/lib/features/dashboard/presentation/widgets/dashboard_sidebar.dart
+++ b/flutter_app/lib/features/dashboard/presentation/widgets/dashboard_sidebar.dart
@@ -1,14 +1,26 @@
 // lib/dashboard/presentation/dashboard_sidebar.dart
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class DashboardSidebar extends StatelessWidget {
+import '../../../auth/controllers/auth_notifier.dart';
+import '../../controllers/location_notifier.dart';
+import '../../data/models.dart';
+
+class DashboardSidebar extends ConsumerStatefulWidget {
   const DashboardSidebar({super.key, this.onSelect});
 
   final ValueChanged<String>? onSelect;
 
   @override
+  ConsumerState<DashboardSidebar> createState() => _DashboardSidebarState();
+}
+
+class _DashboardSidebarState extends ConsumerState<DashboardSidebar> {
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final authState = ref.watch(authNotifierProvider);
+    final locationState = ref.watch(locationNotifierProvider);
 
     return Drawer(
       shape: RoundedRectangleBorder(
@@ -45,13 +57,49 @@ class DashboardSidebar extends StatelessWidget {
                   ),
                   const SizedBox(width: 12),
                   Expanded(
-                    child: Text(
-                      'Company Name',
-                      style: theme.textTheme.titleLarge?.copyWith(
-                        color: Colors.white,
-                        fontWeight: FontWeight.w700,
-                      ),
-                      overflow: TextOverflow.ellipsis,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Flexible(
+                          child: Text(
+                            authState.company?.name ?? '',
+                            style: theme.textTheme.titleLarge?.copyWith(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w700,
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        if (locationState.locations.isNotEmpty)
+                          Flexible(
+                            child: DropdownButton<Location>(
+                              isExpanded: true,
+                              value: locationState.selected,
+                              dropdownColor:
+                                  theme.colorScheme.primaryContainer,
+                              iconEnabledColor: Colors.white,
+                              items: locationState.locations
+                                  .map(
+                                    (l) => DropdownMenuItem<Location>(
+                                      value: l,
+                                      child: Text(
+                                        l.name,
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                    ),
+                                  )
+                                  .toList(),
+                              onChanged: (loc) {
+                                if (loc != null) {
+                                  ref
+                                      .read(locationNotifierProvider.notifier)
+                                      .select(loc);
+                                }
+                              },
+                            ),
+                          ),
+                      ],
                     ),
                   ),
                 ],
@@ -106,7 +154,7 @@ class DashboardSidebar extends StatelessWidget {
       horizontalTitleGap: 12,
       onTap: () {
         Navigator.pop(context);
-        onSelect?.call(label);
+        widget.onSelect?.call(label);
       },
     );
   }

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -13,6 +13,7 @@ import 'features/auth/presentation/login_screen.dart';
 import 'features/auth/data/models.dart';
 import 'features/dashboard/presentation/dashboard_screen.dart';
 import 'package:dio/dio.dart';
+import 'features/dashboard/controllers/location_notifier.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -86,6 +87,11 @@ class _MyAppState extends ConsumerState<MyApp> {
       ref
           .read(authNotifierProvider.notifier)
           .setAuth(user: widget.initialUser!, company: widget.initialCompany);
+      final company = widget.initialCompany;
+      if (company != null) {
+        Future.microtask(() =>
+            ref.read(locationNotifierProvider.notifier).load(company.companyId));
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- convert DashboardSidebar to ConsumerStatefulWidget and show company and location dropdown
- add Location repository and notifier for fetching and persisting selection
- load locations after login or session restore

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8d20bbc0832c998aa153098db7c2