### PR TITLE
Remove obsolete company name from dashboard header

### DIFF
--- a/flutter_app/lib/features/dashboard/presentation/dashboard_screen.dart
+++ b/flutter_app/lib/features/dashboard/presentation/dashboard_screen.dart
@@ -7,7 +7,6 @@ import 'widgets/dashboard_content.dart';
 import 'widgets/dashboard_header.dart';
 import 'widgets/dashboard_sidebar.dart';
 import 'widgets/quick_action_button.dart';
-import '../../auth/controllers/auth_notifier.dart';
 import '../controllers/dashboard_notifier.dart';
 
 class DashboardScreen extends ConsumerStatefulWidget {
@@ -49,8 +48,6 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
     final media = MediaQuery.of(context);
     final width = media.size.width;
 
-    final authState = ref.watch(authNotifierProvider);
-    final companyName = authState.company?.name ?? 'Company';
     final dashboardState = ref.watch(dashboardNotifierProvider);
     final quickCounts = dashboardState.quickActions;
 
@@ -75,7 +72,6 @@ class _DashboardScreenState extends ConsumerState<DashboardScreen> {
               behavior: SnackBarBehavior.floating,
             ));
         },
-        companyName: companyName,
         isOnline: true,
       ),
       drawer: isWide


### PR DESCRIPTION
## Summary
- drop unused company name from DashboardHeader
- clean up unused auth import and local variables

## Testing
- `apt-get install -y flutter` *(fails: Unable to locate package)*
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `flutter build apk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8f33aa98832c9da3613ad2eaf162