### PR TITLE
Delay initial auth provider setup

### DIFF
--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -82,14 +82,17 @@ class _MyAppState extends ConsumerState<MyApp> {
   void initState() {
     super.initState();
     if (widget.initialUser != null) {
-      ref
-          .read(authNotifierProvider.notifier)
-          .setAuth(user: widget.initialUser!, company: widget.initialCompany);
-      final company = widget.initialCompany;
-      if (company != null) {
-        Future.microtask(() =>
-            ref.read(locationNotifierProvider.notifier).load(company.companyId));
-      }
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ref
+            .read(authNotifierProvider.notifier)
+            .setAuth(user: widget.initialUser!, company: widget.initialCompany);
+        final company = widget.initialCompany;
+        if (company != null) {
+          ref
+              .read(locationNotifierProvider.notifier)
+              .load(company.companyId);
+        }
+      });
     }
     if (widget.needsValidation == true) {
       _validating = true;


### PR DESCRIPTION
## Summary
- Defer auth provider initialization until after the first frame to avoid provider mutations during initState

## Testing
- `dart format flutter_app/lib/main.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca132651c832ca1bdf2cdda9f7cb5