### PR TITLE
Improve auth error handling

### DIFF
--- a/flutter_app/lib/features/auth/controllers/auth_notifier.dart
+++ b/flutter_app/lib/features/auth/controllers/auth_notifier.dart
@@ -39,11 +39,16 @@ class AuthNotifier extends StateNotifier<AuthState> {
   Future<LoginResponse?> login({String? username, String? email, required String password}) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
-      final res = await _repository.login(username: username, email: email, password: password);
+      final res =
+          await _repository.login(username: username, email: email, password: password);
       state = state.copyWith(isLoading: false, user: res.user, company: res.company);
       return res;
+    } on AuthException catch (ex) {
+      state = state.copyWith(isLoading: false, error: ex.message);
+      return null;
     } catch (e) {
-      state = state.copyWith(isLoading: false, error: e.toString());
+      state = state.copyWith(
+          isLoading: false, error: 'Login failed. Please try again later.');
       return null;
     }
   }

--- a/flutter_app/lib/features/auth/data/models.dart
+++ b/flutter_app/lib/features/auth/data/models.dart
@@ -1,3 +1,13 @@
+class AuthException implements Exception {
+  final String message;
+  final int? statusCode;
+
+  AuthException(this.message, {this.statusCode});
+
+  @override
+  String toString() => message;
+}
+
 class User {
   final int userId;
   final String username;


### PR DESCRIPTION
## Summary
- introduce `AuthException` for clearer login failures
- map Dio errors to user-friendly auth messages
- surface friendly text in `AuthNotifier` on login

## Testing
- `dart format lib/features/auth/data/models.dart lib/features/auth/data/auth_repository.dart lib/features/auth/controllers/auth_notifier.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca2d5079c832cbed7e4c4f4cc4b77