### PR TITLE
Implement logout workflow with confirmation dialog

### DIFF
--- a/flutter_app/lib/features/auth/controllers/auth_notifier.dart
+++ b/flutter_app/lib/features/auth/controllers/auth_notifier.dart
@@ -1,8 +1,10 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../data/auth_repository.dart';
 import '../data/models.dart';
 import '../../../core/api_client.dart';
+import '../presentation/login_screen.dart';
 
 class AuthState {
   final bool isLoading;
@@ -107,6 +109,15 @@ class AuthNotifier extends StateNotifier<AuthState> {
 
   void setAuth({required User user, Company? company}) {
     state = state.copyWith(user: user, company: company);
+  }
+
+  Future<void> logout(BuildContext context) async {
+    await _repository.logout();
+    state = const AuthState();
+    Navigator.of(context).pushAndRemoveUntil(
+      MaterialPageRoute(builder: (_) => const LoginScreen()),
+      (route) => false,
+    );
   }
 }
 

--- a/flutter_app/lib/features/auth/data/auth_repository.dart
+++ b/flutter_app/lib/features/auth/data/auth_repository.dart
@@ -109,6 +109,17 @@ class AuthRepository {
     return company;
   }
 
+  Future<void> logout() async {
+    try {
+      await _dio.post('/auth/logout');
+    } finally {
+      await _prefs.remove(accessTokenKey);
+      await _prefs.remove(refreshTokenKey);
+      await _prefs.remove(sessionIdKey);
+      await _prefs.remove(companyKey);
+    }
+  }
+
   Future<AuthMeResponse> me() async {
     final response = await _dio.get('/auth/me');
     final data =

--- a/flutter_app/lib/features/dashboard/presentation/widgets/dashboard_sidebar.dart
+++ b/flutter_app/lib/features/dashboard/presentation/widgets/dashboard_sidebar.dart
@@ -170,7 +170,8 @@ class _DashboardSidebarState extends ConsumerState<DashboardSidebar> {
                         ),
                       );
                       if (confirm == true) {
-                        Navigator.popUntil(context, (r) => r.isFirst);
+                        await ref.read(authNotifierProvider.notifier).logout(context);
+                        Navigator.pop(context);
                       }
                     },
                   ),


### PR DESCRIPTION
## Summary
- add repository logout that posts to `/auth/logout` and clears stored credentials
- expose notifier logout to reset auth state and route to login screen
- prompt for confirmation before triggering logout from the dashboard drawer

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca6f6ae48832cb1e1be03edb4b3bf