### PR TITLE
fix: close drawer before logout

### DIFF
--- a/flutter_app/lib/features/dashboard/presentation/widgets/dashboard_sidebar.dart
+++ b/flutter_app/lib/features/dashboard/presentation/widgets/dashboard_sidebar.dart
@@ -151,6 +151,7 @@ class _DashboardSidebarState extends ConsumerState<DashboardSidebar> {
                     ),
                     horizontalTitleGap: 12,
                     onTap: () async {
+                      Navigator.pop(context);
                       final confirm = await showDialog<bool>(
                         context: context,
                         builder: (context) => AlertDialog(
@@ -170,8 +171,9 @@ class _DashboardSidebarState extends ConsumerState<DashboardSidebar> {
                         ),
                       );
                       if (confirm == true) {
-                        await ref.read(authNotifierProvider.notifier).logout(context);
-                        Navigator.pop(context);
+                        await ref
+                            .read(authNotifierProvider.notifier)
+                            .logout(context);
                       }
                     },
                   ),


### PR DESCRIPTION
## Summary
- close sidebar drawer before showing logout confirmation
- rely solely on auth notifier logout for navigation

## Testing
- `dart format lib/features/dashboard/presentation/widgets/dashboard_sidebar.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acaa3c1260832c8f6ee04afd7566bd