### PR TITLE
Ensure login navigation only occurs when context mounted

### DIFF
--- a/flutter_app/lib/features/auth/presentation/login_screen.dart
+++ b/flutter_app/lib/features/auth/presentation/login_screen.dart
@@ -70,7 +70,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           password: _passwordController.text,
         );
 
-    if (!mounted) return;
+    if (!context.mounted) return;
 
     if (res != null) {
       if (res.company == null) {
@@ -81,6 +81,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
         await ref
             .read(locationNotifierProvider.notifier)
             .load(res.company!.companyId);
+        if (!context.mounted) return;
         Navigator.of(context).pushReplacement(
           MaterialPageRoute(builder: (_) => const DashboardScreen()),
         );
@@ -91,7 +92,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   @override
   Widget build(BuildContext context) {
     ref.listen(authNotifierProvider, (prev, next) {
-      if (next.error != null && mounted) {
+      if (next.error != null && context.mounted) {
         ScaffoldMessenger.of(context)
           ..hideCurrentSnackBar()
           ..showSnackBar(


### PR DESCRIPTION
## Summary
- guard dashboard navigation with `context.mounted` after loading location
- replace `mounted` checks with `context.mounted` before navigation and snackbars

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acabe70360832ca0e68102d0ec39b9