### PR TITLE
Keep dashboard drawer open during logout confirmation

### DIFF
--- a/flutter_app/lib/features/dashboard/presentation/widgets/dashboard_sidebar.dart
+++ b/flutter_app/lib/features/dashboard/presentation/widgets/dashboard_sidebar.dart
@@ -151,7 +151,6 @@ class _DashboardSidebarState extends ConsumerState<DashboardSidebar> {
                     ),
                     horizontalTitleGap: 12,
                     onTap: () async {
-                      Navigator.pop(context);
                       final confirm = await showDialog<bool>(
                         context: context,
                         builder: (context) => AlertDialog(


### PR DESCRIPTION
## Summary
- Show logout confirmation dialog without closing the dashboard sidebar
- On confirmation, trigger logout via `authNotifierProvider`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acacc25ba0832c907c1da2846761d2