### PR TITLE
refactor: align IDs with numeric backend fields

### DIFF
--- a/next_frontend_web/src/components/Auth/RegisterPage.tsx
+++ b/next_frontend_web/src/components/Auth/RegisterPage.tsx
@@ -15,7 +15,6 @@ const RegisterPage: React.FC = () => {
   email: '',
   password: '',
   confirmPassword: '',
-  fullName: '',
   
   // Company Information
   companyName: '',
@@ -77,7 +76,7 @@ const RegisterPage: React.FC = () => {
     const isStepValid = () => {
   switch (currentStep) {
     case 1:
-      return formData.fullName && formData.username && formData.email;
+      return formData.username && formData.email;
     case 2:
       return formData.password && formData.confirmPassword && formData.password === formData.confirmPassword;
     case 3:
@@ -93,22 +92,6 @@ const RegisterPage: React.FC = () => {
         case 1:
           return (
             <div className="space-y-6">
-              <div>
-                <label htmlFor="fullName" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                  Full Name
-                </label>
-                <input
-                  id="fullName"
-                  name="fullName"
-                  type="text"
-                  required
-                  value={formData.fullName}
-                  onChange={handleInputChange}
-                  className="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500 dark:bg-gray-800 dark:text-white"
-                  placeholder="Enter your full name"
-                />
-              </div>
-  
               <div>
                 <label htmlFor="username" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                   Username

--- a/next_frontend_web/src/components/ERP/Common/ProductGrid.tsx
+++ b/next_frontend_web/src/components/ERP/Common/ProductGrid.tsx
@@ -156,7 +156,7 @@ const ProductAddDialog: React.FC<{
     {authState.company?.locations
       ?.filter((loc: any) => loc.isActive)
       .map((location: any) => (
-        <option key={location._id} value={location._id}>
+        <option key={location.locationId} value={location.locationId}>
           {location.name}
         </option>
       ))}

--- a/next_frontend_web/src/components/ERP/Customers/CustomerList.tsx
+++ b/next_frontend_web/src/components/ERP/Customers/CustomerList.tsx
@@ -83,7 +83,7 @@ const CustomerList: React.FC<CustomerListProps> = ({
               <td className="px-6 py-4 whitespace-nowrap">
                   <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-800 text-blue-800 dark:text-blue-200">
                   {authState.company?.locations?.find(
-                    (loc: any) => loc._id === customer.locationId
+                    (loc: any) => loc.locationId.toString() === customer.locationId
                   )?.name || 'Unknown'}
                 </span>
                 <div className="flex items-center mt-2">

--- a/next_frontend_web/src/components/ERP/Customers/CustomerManagement.tsx
+++ b/next_frontend_web/src/components/ERP/Customers/CustomerManagement.tsx
@@ -61,7 +61,7 @@ const CustomerManagement: React.FC = () => {
       phone: '',
       email: '',
       address: '',
-      locationId: state.currentLocationId || '',
+      locationId: state.currentLocationId?.toString() || '',
       creditLimit: 0,
       notes: ''
     });
@@ -262,7 +262,7 @@ const CustomerManagement: React.FC = () => {
                 <select required value={formData.locationId} onChange={e => setFormData(prev => ({ ...prev, locationId: e.target.value }))} className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500 dark:bg-gray-800 dark:text-white">
                   <option value="">Select Location</option>
                   {authState.company?.locations?.map((loc: Location) => (
-                    <option key={loc._id} value={loc._id}>{loc.name}</option>
+                    <option key={loc.locationId} value={loc.locationId}>{loc.name}</option>
                   ))}
                 </select>
               </div>
@@ -315,7 +315,7 @@ const CustomerManagement: React.FC = () => {
                 <select required value={formData.locationId} onChange={e => setFormData(prev => ({ ...prev, locationId: e.target.value }))} className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-red-500 focus:border-red-500 dark:bg-gray-800 dark:text-white">
                   <option value="">Select Location</option>
                   {authState.company?.locations?.map((loc: Location) => (
-                    <option key={loc._id} value={loc._id}>{loc.name}</option>
+                    <option key={loc.locationId} value={loc.locationId}>{loc.name}</option>
                   ))}
                 </select>
               </div>

--- a/next_frontend_web/src/components/ERP/Dashboard.tsx
+++ b/next_frontend_web/src/components/ERP/Dashboard.tsx
@@ -73,7 +73,7 @@ const Dashboard: React.FC = () => {
         <div className="mb-6">
           <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-2">Dashboard</h1>
           <p className="text-gray-600 dark:text-gray-400">
-            Welcome back, {authState.user?.fullName}! 
+            Welcome back, {authState.user?.username}!
           </p>
         </div>
         
@@ -225,7 +225,7 @@ const Dashboard: React.FC = () => {
           <div>
             <h1 className="text-3xl font-bold text-gray-800 dark:text-white mb-2">Dashboard</h1>
             <p className="text-gray-600 dark:text-gray-400">
-              Welcome back, {authState.user?.fullName}! Here's how your business is doing today.
+              Welcome back, {authState.user?.username}! Here's how your business is doing today.
             </p>
           </div>
         </div>

--- a/next_frontend_web/src/components/ERP/Inventory/ProductManagement.tsx
+++ b/next_frontend_web/src/components/ERP/Inventory/ProductManagement.tsx
@@ -83,7 +83,7 @@ const ProductManagement: React.FC = () => {
 
   const getStockForLocation = (product: Product) => {
     if (product.stockLevels && state.currentLocationId) {
-      const level = product.stockLevels.find(l => l.locationId === state.currentLocationId);
+      const level = product.stockLevels.find(l => l.locationId === state.currentLocationId?.toString());
       return level ? level.quantity : 0;
     }
     return product.stock;
@@ -110,8 +110,8 @@ const ProductManagement: React.FC = () => {
     if (state.currentLocationId) {
       filtered = filtered.filter(p =>
         p.stockLevels
-          ? p.stockLevels.some(l => l.locationId === state.currentLocationId)
-          : p.locationId === state.currentLocationId
+          ? p.stockLevels.some(l => l.locationId === state.currentLocationId?.toString())
+          : p.locationId === state.currentLocationId?.toString()
       );
     }
 
@@ -157,7 +157,7 @@ const ProductManagement: React.FC = () => {
     brand: '',
     model: '',
     sku: '',
-    locationId: state.currentLocationId || '', // Default to current location
+    locationId: state.currentLocationId?.toString() || '', // Default to current location
     supplierId: '',
     description: '',
     warranty: '',
@@ -280,7 +280,7 @@ const ProductManagement: React.FC = () => {
       brand: product.brand || '',
       model: product.model || '',
       sku: product.sku,
-      locationId: product.locationId || state.currentLocationId || '', // Add this
+      locationId: product.locationId || state.currentLocationId?.toString() || '', // Add this
       supplierId: product.supplierId || '',
       description: product.description || '',
       warranty: product.warranty || '',
@@ -867,7 +867,7 @@ const ProductManagement: React.FC = () => {
   >
     <option value="">Select Location</option>
     {authState.company?.locations?.filter((loc: Location) => loc.isActive).map((location: Location) => (
-      <option key={location._id} value={location._id}>
+      <option key={location.locationId} value={location.locationId}>
         {location.name}
       </option>
     ))}
@@ -1114,7 +1114,7 @@ const ProductManagement: React.FC = () => {
   >
     <option value="">Select Location</option>
     {authState.company?.locations?.filter((loc: Location) => loc.isActive).map((location: Location) => (
-      <option key={location._id} value={location._id}>
+      <option key={location.locationId} value={location.locationId}>
         {location.name}
       </option>
     ))}
@@ -1232,7 +1232,7 @@ const ProductManagement: React.FC = () => {
   >
     <option value="">Select Location</option>
     {authState.company?.locations?.filter((loc: Location) => loc.isActive).map((location: Location) => (
-      <option key={location._id} value={location._id}>
+      <option key={location.locationId} value={location.locationId}>
         {location.name}
       </option>
     ))}

--- a/next_frontend_web/src/components/Layout/Header.tsx
+++ b/next_frontend_web/src/components/Layout/Header.tsx
@@ -51,7 +51,7 @@ const Header: React.FC = () => {
     dispatch({ type: 'TOGGLE_THEME' });
   };
 
- const handleLocationChange = async (locationId: string) => {
+ const handleLocationChange = async (locationId: number) => {
   if (state.isLoading) return;
   
   try {
@@ -86,7 +86,7 @@ const Header: React.FC = () => {
     };
   }, []);
 
-  const currentLocation = authState.company?.locations?.find((loc: Location) => loc._id === state.currentLocationId);
+  const currentLocation = authState.company?.locations?.find((loc: Location) => loc.locationId === state.currentLocationId);
 
 
   return (
@@ -146,18 +146,18 @@ const Header: React.FC = () => {
     <div className="absolute top-full left-0 mt-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg shadow-lg z-50 min-w-48">
       {authState.company.locations.map((location: Location) => (
         <button
-          key={location._id}
-          onClick={() => handleLocationChange(location._id)}
+          key={location.locationId}
+          onClick={() => handleLocationChange(location.locationId)}
           disabled={state.isLoading}
           className={`w-full text-left px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-700 first:rounded-t-lg last:rounded-b-lg transition-colors disabled:opacity-50 ${
-            location._id === state.currentLocationId 
-              ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300' 
+            location.locationId === state.currentLocationId
+              ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
               : 'text-gray-800 dark:text-white'
           }`}
         >
           <div className="font-medium">{location.name}</div>
           <div className="text-xs text-gray-500 dark:text-gray-400">{location.address}</div>
-          {location._id === state.currentLocationId && (
+          {location.locationId === state.currentLocationId && (
             <div className="text-xs text-blue-600 dark:text-blue-400 mt-1">Current Location</div>
           )}
         </button>
@@ -276,7 +276,7 @@ const Header: React.FC = () => {
           <div className="flex items-center space-x-2">
             <div className="hidden md:block text-right">
               <div className="text-sm font-medium text-gray-800 dark:text-white">
-                {authState.user?.fullName}
+                {authState.user?.username}
               </div>
               <div className="text-xs text-gray-500 dark:text-gray-400">
                 {authState.user?.roleName || authState.user?.roleId}

--- a/next_frontend_web/src/components/MainApp.tsx
+++ b/next_frontend_web/src/components/MainApp.tsx
@@ -27,7 +27,7 @@ const MainApp: React.FC = () => {
             Loading your workspace...
           </p>
           <p className="text-sm text-gray-500 dark:text-gray-500 mt-2">
-            Welcome {authState.user?.fullName}
+            Welcome {authState.user?.username}
           </p>
         </div>
       </div>
@@ -82,9 +82,9 @@ const MainApp: React.FC = () => {
           <div className="space-y-2">
             {locations.map((location: Location) => (
               <button
-                key={location._id}
+                key={location.locationId}
                 // onClick={() => {
-                //   dispatch({ type: 'SET_CURRENT_LOCATION', payload: location._id });
+                //   dispatch({ type: 'SET_CURRENT_LOCATION', payload: location.locationId });
                 // }}
                 className="w-full p-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               >

--- a/next_frontend_web/src/context/MainContext.tsx
+++ b/next_frontend_web/src/context/MainContext.tsx
@@ -465,14 +465,14 @@ export const MainProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const setCurrentCompany = useCallback(
-    (companyId: string) => {
+    (companyId: number) => {
       dispatch({ type: 'SET_CURRENT_COMPANY', payload: companyId });
     },
     [dispatch]
   );
 
   const setCurrentLocation = useCallback(
-    (locationId: string) => {
+    (locationId: number) => {
       dispatch({ type: 'SET_CURRENT_LOCATION', payload: locationId });
     },
     [dispatch]
@@ -494,8 +494,8 @@ export const MainProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     if (authState.isAuthenticated && authState.company) {
-      const companyId = authState.company._id;
-      const locationId = authState.company.locations?.[0]?._id;
+      const companyId = authState.company.companyId;
+      const locationId = authState.company.locations?.[0]?.locationId;
       if (companyId && companyId !== state.currentCompanyId) {
         setCurrentCompany(companyId);
       }

--- a/next_frontend_web/src/pages/login.tsx
+++ b/next_frontend_web/src/pages/login.tsx
@@ -12,8 +12,8 @@ const Login: React.FC = () => {
 
   useEffect(() => {
     if (state.isAuthenticated && state.company) {
-      setCurrentCompany(state.company._id);
-      const defaultLocation = state.company.locations?.[0]?._id;
+      setCurrentCompany(state.company.companyId);
+      const defaultLocation = state.company.locations?.[0]?.locationId;
       if (defaultLocation) {
         setCurrentLocation(defaultLocation);
       }

--- a/next_frontend_web/src/services/auth.ts
+++ b/next_frontend_web/src/services/auth.ts
@@ -1,5 +1,5 @@
 import api, { setAuthTokens, clearAuthTokens } from './apiClient';
-import { User, Company } from '../types';
+import { User, Company, Location } from '../types';
 
 /**
  * Payload sent to the backend when a user attempts to log in.
@@ -37,6 +37,53 @@ export interface RegisterResponse {
   message: string;
 }
 
+const mapLocation = (loc: any): Location => ({
+  locationId: loc.locationId,
+  name: loc.name,
+  address: loc.address,
+  phone: loc.phone,
+  email: loc.email,
+  code: loc.code,
+  isActive: loc.isActive,
+  companyId: loc.companyId,
+  settings: loc.settings,
+  createdAt: loc.createdAt,
+  updatedAt: loc.updatedAt,
+});
+
+const mapCompany = (company: any): Company => ({
+  companyId: company.companyId,
+  name: company.name,
+  code: company.code,
+  address: company.address,
+  phone: company.phone,
+  email: company.email,
+  taxNumber: company.taxNumber,
+  website: company.website,
+  logo: company.logo,
+  isActive: company.isActive,
+  locations: company.locations?.map(mapLocation) ?? [],
+  settings: company.settings,
+  createdAt: company.createdAt,
+  updatedAt: company.updatedAt,
+});
+
+const mapUser = (user: any): User => ({
+  userId: user.userId,
+  username: user.username,
+  email: user.email,
+  roleId: user.roleId,
+  roleName: user.roleName,
+  companyId: user.companyId,
+  locationId: user.locationId,
+  isActive: user.isActive,
+  permissions: user.permissions,
+  primaryLanguage: user.primaryLanguage,
+  secondaryLanguage: user.secondaryLanguage,
+  createdAt: user.createdAt,
+  updatedAt: user.updatedAt,
+});
+
 export const login = async (
   email: string,
   password: string,
@@ -49,7 +96,7 @@ export const login = async (
     { auth: false }
   );
   setAuthTokens({ accessToken: data.accessToken, refreshToken: data.refreshToken });
-  return { user: data.user, company: data.company, sessionId: data.sessionId };
+  return { user: mapUser(data.user), company: mapCompany(data.company), sessionId: data.sessionId };
 };
 
 export const register = async (
@@ -61,8 +108,10 @@ export const register = async (
     { auth: false }
   );
 
-export const getProfile = () =>
-  api.get<{ user: User; company: Company }>('/api/v1/auth/me');
+export const getProfile = async () => {
+  const data = await api.get<{ user: any; company: any }>('/api/v1/auth/me');
+  return { user: mapUser(data.user), company: mapCompany(data.company) };
+};
 
 export const logout = async () => {
   await api.post('/api/v1/auth/logout');

--- a/next_frontend_web/src/types/index.ts
+++ b/next_frontend_web/src/types/index.ts
@@ -10,14 +10,14 @@ export enum ROLES {
 }
 
 export interface User {
-  _id: string;
+  userId: number;
   username: string;
   email: string;
-  fullName: string;
   // 1=Super Admin, 2=Admin, 3=Manager, 4=Sales, 5=Inventory, 6=Accountant, 7=Cashier, 8=HR
   roleId: number;
   roleName?: string;
-  companyId: string;
+  companyId: number;
+  locationId?: number;
   isActive: boolean;
   permissions: string[];
   primaryLanguage?: string;
@@ -27,14 +27,14 @@ export interface User {
 }
 
 export interface Location {
-  _id: string;
+  locationId: number;
   name: string;
   address: string;
   phone?: string;
   email?: string;
   code: string; // Unique location code
   isActive: boolean;
-  companyId: string;
+  companyId: number;
   settings?: {
     timezone?: string;
     currency?: string;
@@ -44,7 +44,7 @@ export interface Location {
 }
 
 export interface Company {
-  _id: string;
+  companyId: number;
   name: string;
   code: string;
   address: string;
@@ -283,8 +283,8 @@ export interface AppState {
   isLoading: boolean;
   isInitialized: boolean;
   error: string | null;
-  currentCompanyId: string | null;
-  currentLocationId: string | null;
+  currentCompanyId: number | null;
+  currentLocationId: number | null;
   
   // Cart State
   cart: CartItem[];
@@ -466,15 +466,15 @@ export interface SupplierFormData {
   email: string;
   address: string;
   notes: string;
-  companyId: string;
-  locationId: string;
+  companyId: number;
+  locationId: number;
 }
 
 export interface CategoryFormData {
   name: string;
   description: string;
-  companyId: string;
-  locationId: string;
+  companyId: number;
+  locationId: number;
 }
 // Utility Types
 export type EntityId = string;
@@ -483,8 +483,8 @@ export type Currency = number;
 
 // Action Types for Reducers
 type AppAction =
-  | { type: 'SET_CURRENT_COMPANY'; payload: string }
-  | { type: 'SET_CURRENT_LOCATION'; payload: string }
+  | { type: 'SET_CURRENT_COMPANY'; payload: number }
+  | { type: 'SET_CURRENT_LOCATION'; payload: number }
   | { type: 'LOAD_ALL_DATA' }
   | { type: 'SET_LOADING'; payload: boolean }
   | { type: 'SET_INITIALIZED'; payload: boolean }


### PR DESCRIPTION
## Summary
- Switch core types to numeric IDs and drop legacy `fullName`
- Update login, context, and UI components to use `companyId`/`locationId`
- Map auth responses to new user and company shapes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68af32653ed4832c8d29ac08a8349120