### PR TITLE
Add services for device sessions and inventory metadata

### DIFF
--- a/go_backend_rmt/internal/routes/FRONTEND_PARITY.md
+++ b/go_backend_rmt/internal/routes/FRONTEND_PARITY.md
@@ -5,7 +5,7 @@ The table below tracks whether each backend route group in `routes.go` has a cor
 | Route Group | Frontend Module | Notes |
 |-------------|----------------|-------|
 | `/auth` | `src/services/auth.ts` | |
-| `/device-sessions` | — | Not used in frontend yet |
+| `/device-sessions` | `src/services/deviceSessions.ts` | |
 | `/dashboard` | `src/services/dashboard.ts` | |
 | `/users` | `src/services/users.ts` | Added for parity |
 | `/companies` | `src/services/companies.ts` | |
@@ -14,9 +14,9 @@ The table below tracks whether each backend route group in `routes.go` has a cor
 | `/permissions` | `src/services/roles.ts` | Exposed via getPermissions |
 | `/products` | `src/services/products.ts` | |
 | `/categories` | `src/services/categories.ts` | |
-| `/brands` | — | Not currently used |
-| `/units` | — | Not currently used |
-| `/product-attribute-definitions` | — | Not currently used |
+| `/brands` | `src/services/brands.ts` | |
+| `/units` | `src/services/units.ts` | |
+| `/product-attribute-definitions` | `src/services/productAttributes.ts` | |
 | `/inventory` | `src/services/inventory.ts` | |
 | `/sales` | `src/services/sales.ts` | Quote helpers pending |
 | `/pos` | — | POS UI not implemented |
@@ -25,31 +25,31 @@ The table below tracks whether each backend route group in `routes.go` has a cor
 | `/loyalty` | — | Reserved for future feature |
 | `/promotions` | — | Reserved for future feature |
 | `/sale-returns` | — | Reserved for future feature |
-| `/purchases` | `src/services/purchases.ts` | Listing endpoints not used |
+| `/purchases` | `src/services/purchases.ts` | |
 | `/purchase-orders` | `src/services/purchases.ts` | |
 | `/goods-receipts` | `src/services/purchases.ts` | |
 | `/purchase-returns` | `src/services/purchases.ts` | |
 | `/customers` | `src/services/customers.ts` | |
 | `/employees` | `src/services/employees.ts` | Added for parity |
 | `/attendance` | `src/services/attendance.ts` | Added for parity |
-| `/payrolls` | — | Not currently used |
-| `/collections` | — | Not currently used |
-| `/expenses` | — | Not currently used |
+| `/payrolls` | — | Intentionally unused |
+| `/collections` | — | Intentionally unused |
+| `/expenses` | — | Intentionally unused |
 | `/vouchers` | `src/services/accounting.ts` | |
 | `/ledgers` | `src/services/accounting.ts` | |
 | `/cash-registers` | `src/services/accounting.ts` | |
-| `/reports` | — | Not currently used |
+| `/reports` | — | Intentionally unused |
 | `/suppliers` | `src/services/suppliers.ts` | |
-| `/currencies` | — | Not currently used |
-| `/taxes` | — | Not currently used |
-| `/settings` | — | Not currently used |
-| `/audit-logs` | — | Not currently used |
-| `/languages` | — | Not currently used |
-| `/translations` | — | Not currently used |
-| `/user-preferences` | — | Not currently used |
-| `/numbering-sequences` | — | Not currently used |
-| `/invoice-templates` | — | Not currently used |
-| `/print` | — | Not currently used |
-| `/workflow-requests` | — | Not currently used |
+| `/currencies` | — | Intentionally unused |
+| `/taxes` | — | Intentionally unused |
+| `/settings` | — | Intentionally unused |
+| `/audit-logs` | — | Intentionally unused |
+| `/languages` | — | Intentionally unused |
+| `/translations` | — | Intentionally unused |
+| `/user-preferences` | — | Intentionally unused |
+| `/numbering-sequences` | — | Intentionally unused |
+| `/invoice-templates` | — | Intentionally unused |
+| `/print` | — | Intentionally unused |
+| `/workflow-requests` | — | Intentionally unused |
 
 This document should be updated whenever new service modules are created or an unused endpoint becomes active.

--- a/next_frontend_web/src/services/brands.ts
+++ b/next_frontend_web/src/services/brands.ts
@@ -1,0 +1,7 @@
+import api from './apiClient';
+import { Brand } from '../types';
+
+export const getBrands = () => api.get<Brand[]>('/api/v1/brands');
+
+export const createBrand = (payload: Partial<Brand>) =>
+  api.post<Brand>('/api/v1/brands', payload);

--- a/next_frontend_web/src/services/deviceSessions.ts
+++ b/next_frontend_web/src/services/deviceSessions.ts
@@ -1,0 +1,8 @@
+import api from './apiClient';
+import { DeviceSession } from '../types';
+
+export const getDeviceSessions = () =>
+  api.get<DeviceSession[]>('/api/v1/device-sessions');
+
+export const revokeDeviceSession = (sessionId: string) =>
+  api.delete<DeviceSession>(`/api/v1/device-sessions/${sessionId}`);

--- a/next_frontend_web/src/services/index.ts
+++ b/next_frontend_web/src/services/index.ts
@@ -15,3 +15,7 @@ export * as roles from './roles';
 export * as locations from './locations';
 export * as employees from './employees';
 export * as attendance from './attendance';
+export * as deviceSessions from './deviceSessions';
+export * as brands from './brands';
+export * as units from './units';
+export * as productAttributes from './productAttributes';

--- a/next_frontend_web/src/services/productAttributes.ts
+++ b/next_frontend_web/src/services/productAttributes.ts
@@ -1,0 +1,27 @@
+import api from './apiClient';
+import { ProductAttributeDefinition } from '../types';
+
+export const getAttributeDefinitions = () =>
+  api.get<ProductAttributeDefinition[]>('/api/v1/product-attribute-definitions');
+
+export const createAttributeDefinition = (
+  payload: Partial<ProductAttributeDefinition>
+) =>
+  api.post<ProductAttributeDefinition>(
+    '/api/v1/product-attribute-definitions',
+    payload
+  );
+
+export const updateAttributeDefinition = (
+  id: string,
+  payload: Partial<ProductAttributeDefinition>
+) =>
+  api.put<ProductAttributeDefinition>(
+    `/api/v1/product-attribute-definitions/${id}`,
+    payload
+  );
+
+export const deleteAttributeDefinition = (id: string) =>
+  api.delete<void>(
+    `/api/v1/product-attribute-definitions/${id}`
+  );

--- a/next_frontend_web/src/services/purchases.ts
+++ b/next_frontend_web/src/services/purchases.ts
@@ -6,10 +6,49 @@ import {
   GoodsReceipt,
   PurchaseReturnPayload,
   PurchaseReturn,
+  Purchase,
 } from '../types/purchases';
+
+export const getPurchases = (query = '') =>
+  api.get<Purchase[]>(`/api/v1/purchases${query}`);
+
+export const getPurchaseHistory = () =>
+  api.get<any>('/api/v1/purchases/history');
+
+export const getPendingPurchases = () =>
+  api.get<Purchase[]>(`/api/v1/purchases/pending`);
+
+export const getPurchase = (id: string) =>
+  api.get<Purchase>(`/api/v1/purchases/${id}`);
+
+export const createPurchase = (payload: any) =>
+  api.post<Purchase>('/api/v1/purchases', payload);
+
+export const createQuickPurchase = (payload: any) =>
+  api.post<Purchase>('/api/v1/purchases/quick', payload);
+
+export const updatePurchase = (id: string, payload: any) =>
+  api.put<Purchase>(`/api/v1/purchases/${id}`, payload);
+
+export const receivePurchase = (id: string, payload: any) =>
+  api.put<Purchase>(`/api/v1/purchases/${id}/receive`, payload);
+
+export const deletePurchase = (id: string) =>
+  api.delete<void>(`/api/v1/purchases/${id}`);
 
 export const createPurchaseOrder = (payload: PurchaseOrderPayload) =>
   api.post<PurchaseOrder>('/api/v1/purchase-orders', payload);
+
+export const updatePurchaseOrder = (
+  id: string,
+  payload: Partial<PurchaseOrder>
+) => api.put<PurchaseOrder>(`/api/v1/purchase-orders/${id}`, payload);
+
+export const deletePurchaseOrder = (id: string) =>
+  api.delete<void>(`/api/v1/purchase-orders/${id}`);
+
+export const approvePurchaseOrder = (id: string) =>
+  api.put<PurchaseOrder>(`/api/v1/purchase-orders/${id}/approve`);
 
 export const recordGoodsReceipt = (payload: GoodsReceiptPayload) =>
   api.post<GoodsReceipt | null>('/api/v1/goods-receipts', payload);
@@ -18,3 +57,17 @@ export const createPurchaseReturn = (payload: PurchaseReturnPayload) => {
   // payload items should include purchaseDetailId
   return api.post<PurchaseReturn>('/api/v1/purchase-returns', payload);
 };
+
+export const getPurchaseReturns = () =>
+  api.get<PurchaseReturn[]>('/api/v1/purchase-returns');
+
+export const getPurchaseReturn = (id: string) =>
+  api.get<PurchaseReturn>(`/api/v1/purchase-returns/${id}`);
+
+export const updatePurchaseReturn = (
+  id: string,
+  payload: PurchaseReturnPayload
+) => api.put<PurchaseReturn>(`/api/v1/purchase-returns/${id}`, payload);
+
+export const deletePurchaseReturn = (id: string) =>
+  api.delete<void>(`/api/v1/purchase-returns/${id}`);

--- a/next_frontend_web/src/services/units.ts
+++ b/next_frontend_web/src/services/units.ts
@@ -1,0 +1,7 @@
+import api from './apiClient';
+import { Unit } from '../types';
+
+export const getUnits = () => api.get<Unit[]>('/api/v1/units');
+
+export const createUnit = (payload: Partial<Unit>) =>
+  api.post<Unit>('/api/v1/units', payload);

--- a/next_frontend_web/src/types/index.ts
+++ b/next_frontend_web/src/types/index.ts
@@ -101,6 +101,34 @@ export interface ProductStockLevel {
   quantity: number;
 }
 
+export interface Brand {
+  brandId: number;
+  name: string;
+  description?: string;
+  isActive?: boolean;
+}
+
+export interface Unit {
+  unitId: number;
+  name: string;
+  symbol?: string;
+  baseUnitId?: number;
+  conversionFactor?: number;
+}
+
+export interface DeviceSession {
+  sessionId: string;
+  deviceId: string;
+  deviceName?: string;
+  ipAddress?: string;
+  userAgent?: string;
+  lastSeen: string;
+  lastSyncTime?: string;
+  isActive: boolean;
+  isStale: boolean;
+  createdAt: string;
+}
+
 export interface Product extends AuditFields {
   _id: string;
   name: string;
@@ -540,6 +568,9 @@ export type {
   Customer as CustomerType,
   Sale as SaleType,
   Supplier as SupplierType,
+  Brand,
+  Unit,
+  DeviceSession,
   AuthAction,
   AppAction,
 };

--- a/next_frontend_web/src/types/purchases.ts
+++ b/next_frontend_web/src/types/purchases.ts
@@ -19,6 +19,15 @@ export interface PurchaseOrder {
   items: PurchaseOrderItemPayload[];
 }
 
+export interface Purchase {
+  purchaseId: number;
+  supplierId: number;
+  status: string;
+  totalAmount: number;
+  items?: PurchaseOrderItemPayload[];
+  [key: string]: any;
+}
+
 export interface GoodsReceiptItemPayload {
   purchaseDetailId: number;
   receivedQuantity: number;


### PR DESCRIPTION
## Summary
- add API clients for device sessions, brands, units, and product attribute definitions
- expand purchases service with listing, retrieval, and management endpoints
- document frontend parity and mark unused backend routes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af419b0014832cb6ddfc6b15c8dbe1