### PR TITLE
feat: add quick sale workflow

### DIFF
--- a/next_frontend_web/src/components/ERP/Sales/QuickSale.tsx
+++ b/next_frontend_web/src/components/ERP/Sales/QuickSale.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import { createQuickSale } from '../../../services/sales';
+
+export interface QuickSaleItem {
+  price: number;
+  quantity: number;
+}
+
+interface QuickSaleProps {
+  items: QuickSaleItem[];
+  onChange: (items: QuickSaleItem[]) => void;
+}
+
+const QuickSale: React.FC<QuickSaleProps> = ({ items, onChange }) => {
+  const [price, setPrice] = useState('');
+  const [quantity, setQuantity] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const addItem = () => {
+    const p = parseFloat(price);
+    const q = parseFloat(quantity);
+    if (p > 0 && q > 0) {
+      onChange([...items, { price: p, quantity: q }]);
+      setPrice('');
+      setQuantity('');
+    }
+  };
+
+  const removeItem = (index: number) => {
+    onChange(items.filter((_, i) => i !== index));
+  };
+
+  const total = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+
+  const handleSubmit = async () => {
+    if (items.length === 0) return;
+    setLoading(true);
+    try {
+      await createQuickSale({ items, total });
+      onChange([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex space-x-2">
+        <input
+          type="number"
+          value={price}
+          onChange={e => setPrice(e.target.value)}
+          placeholder="Price"
+          className="border p-2 flex-1"
+        />
+        <input
+          type="number"
+          value={quantity}
+          onChange={e => setQuantity(e.target.value)}
+          placeholder="Qty"
+          className="border p-2 flex-1"
+        />
+        <button
+          onClick={addItem}
+          className="px-4 py-2 bg-blue-500 text-white rounded"
+        >
+          Add
+        </button>
+      </div>
+
+      <div className="space-y-2">
+        {items.map((item, idx) => (
+          <div
+            key={idx}
+            className="flex justify-between items-center border p-2 rounded"
+          >
+            <span>
+              {item.quantity} x {item.price.toFixed(2)}
+            </span>
+            <span>{(item.quantity * item.price).toFixed(2)}</span>
+            <button
+              onClick={() => removeItem(idx)}
+              className="text-red-500"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div className="font-bold">Total: {total.toFixed(2)}</div>
+
+      <button
+        onClick={handleSubmit}
+        className="px-4 py-2 bg-green-600 text-white rounded"
+        disabled={items.length === 0 || loading}
+      >
+        {loading ? 'Saving...' : 'Submit'}
+      </button>
+    </div>
+  );
+};
+
+export default QuickSale;

--- a/next_frontend_web/src/pages/sales/quick.tsx
+++ b/next_frontend_web/src/pages/sales/quick.tsx
@@ -1,13 +1,14 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 import MainLayout from '../../components/Layout/MainLayout';
-import ClassicPOS from '../../components/ERP/Sales/ClassicPOS';
+import QuickSale, { QuickSaleItem } from '../../components/ERP/Sales/QuickSale';
 import { ROLES } from '../../types';
 
 const QuickSalesPage: React.FC = () => {
   const { state, hasRole } = useAuth();
   const router = useRouter();
+  const [items, setItems] = useState<QuickSaleItem[]>([]);
 
   useEffect(() => {
     if (!state.isInitialized) return;
@@ -16,12 +17,27 @@ const QuickSalesPage: React.FC = () => {
     }
   }, [state.isInitialized, state.isAuthenticated, router]);
 
+  useEffect(() => {
+    const saved = localStorage.getItem('quick-sale-items');
+    if (saved) {
+      try {
+        setItems(JSON.parse(saved));
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('quick-sale-items', JSON.stringify(items));
+  }, [items]);
+
   if (!state.isInitialized || !state.isAuthenticated) return null;
   if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER, ROLES.SALES])) return <div>Access denied</div>;
 
   return (
     <MainLayout>
-      <ClassicPOS />
+      <QuickSale items={items} onChange={setItems} />
     </MainLayout>
   );
 };

--- a/next_frontend_web/src/services/sales.ts
+++ b/next_frontend_web/src/services/sales.ts
@@ -3,3 +3,5 @@ import { Sale } from '../types';
 
 export const getSales = () => api.get<Sale[]>('/api/v1/sales');
 export const createSale = (payload: Partial<Sale>) => api.post<Sale>('/api/v1/sales', payload);
+export const createQuickSale = (payload: any) =>
+  api.post('/api/v1/sales/quick', payload);


### PR DESCRIPTION
## Summary
- add QuickSale component to handle price/quantity-only sales
- extend sales service with createQuickSale endpoint
- persist quick sale items on dedicated quick sales page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af4526b610832c955a2b481c3735e1