### PR TITLE
Add hold/resume sales and loyalty helpers

### DIFF
--- a/next_frontend_web/src/services/sales.ts
+++ b/next_frontend_web/src/services/sales.ts
@@ -5,3 +5,15 @@ export const getSales = () => api.get<Sale[]>('/api/v1/sales');
 export const createSale = (payload: Partial<Sale>) => api.post<Sale>('/api/v1/sales', payload);
 export const createQuickSale = (payload: any) =>
   api.post('/api/v1/sales/quick', payload);
+
+export const holdSale = (id: string) =>
+  api.post<Sale>(`/api/v1/sales/${id}/hold`);
+
+export const resumeSale = (id: string) =>
+  api.post<Sale>(`/api/v1/sales/${id}/resume`);
+
+export const applyPromotion = (id: string, code: string) =>
+  api.post<Sale>(`/api/v1/sales/${id}/promotion`, { code });
+
+export const applyLoyaltyPoints = (id: string, points: number) =>
+  api.post<Sale>(`/api/v1/sales/${id}/loyalty`, { points });


### PR DESCRIPTION
## Summary
- add hold and resume sale endpoints with promotion and loyalty helpers
- expose Hold/Resume, barcode, loyalty, promotion, and warranty fields in sales UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af461e7964832cb5d07cdac11efce8