### PR TITLE
feat: add sales history filters and export

### DIFF
--- a/next_frontend_web/src/components/ERP/Sales/SalesHistory.tsx
+++ b/next_frontend_web/src/components/ERP/Sales/SalesHistory.tsx
@@ -1,12 +1,132 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { useAppState } from '../../../context/MainContext';
+import { getSalesHistory, exportSalesHistory } from '../../../services/sales';
+import { Sale } from '../../../types';
 
 const SalesHistory: React.FC = () => {
-  const state = useAppState(s => s);
+  const { customers, products } = useAppState(s => ({
+    customers: s.customers,
+    products: s.products,
+  }));
+  const [filters, setFilters] = useState({
+    startDate: '',
+    endDate: '',
+    customerId: '',
+    productId: '',
+    paymentMethod: '',
+  });
+  const [data, setData] = useState<Sale[]>([]);
+
+  const loadData = async () => {
+    try {
+      const res = await getSalesHistory(filters);
+      setData(res);
+    } catch (err) {
+      console.error('Failed to load sales history', err);
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleExport = async () => {
+    try {
+      const blob = await exportSalesHistory(filters);
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'sales-history.csv';
+      a.click();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Failed to export sales history', err);
+    }
+  };
 
   return (
     <div className="p-4">
       <h2 className="text-xl font-semibold mb-4">Sales History</h2>
+      <div className="flex flex-wrap gap-4 mb-4">
+        <div>
+          <label className="block text-sm mb-1">From</label>
+          <input
+            type="date"
+            value={filters.startDate}
+            onChange={e => setFilters({ ...filters, startDate: e.target.value })}
+            className="border px-2 py-1"
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">To</label>
+          <input
+            type="date"
+            value={filters.endDate}
+            onChange={e => setFilters({ ...filters, endDate: e.target.value })}
+            className="border px-2 py-1"
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Customer</label>
+          <select
+            value={filters.customerId}
+            onChange={e => setFilters({ ...filters, customerId: e.target.value })}
+            className="border px-2 py-1"
+          >
+            <option value="">All</option>
+            {customers.map(c => (
+              <option key={c._id} value={c._id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Product</label>
+          <select
+            value={filters.productId}
+            onChange={e => setFilters({ ...filters, productId: e.target.value })}
+            className="border px-2 py-1"
+          >
+            <option value="">All</option>
+            {products.map(p => (
+              <option key={p._id} value={p._id}>
+                {p.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Payment</label>
+          <select
+            value={filters.paymentMethod}
+            onChange={e =>
+              setFilters({ ...filters, paymentMethod: e.target.value })
+            }
+            className="border px-2 py-1"
+          >
+            <option value="">All</option>
+            <option value="cash">Cash</option>
+            <option value="card">Card</option>
+            <option value="upi">UPI</option>
+            <option value="netbanking">Net Banking</option>
+            <option value="credit">Credit</option>
+          </select>
+        </div>
+        <button
+          onClick={loadData}
+          className="self-end bg-blue-500 text-white px-4 py-2 rounded"
+        >
+          Filter
+        </button>
+        <button
+          onClick={handleExport}
+          className="self-end bg-green-600 text-white px-4 py-2 rounded"
+        >
+          Export
+        </button>
+      </div>
       <table className="w-full text-left border">
         <thead>
           <tr>
@@ -16,17 +136,19 @@ const SalesHistory: React.FC = () => {
           </tr>
         </thead>
         <tbody>
-          {state.recentSales.map(sale => (
+          {data.map(sale => (
             <tr key={sale._id}>
               <td className="border px-2 py-1">{sale.saleNumber}</td>
-              <td className="border px-2 py-1">{sale.date ? new Date(sale.date).toLocaleString() : ''}</td>
+              <td className="border px-2 py-1">
+                {sale.date ? new Date(sale.date).toLocaleString() : ''}
+              </td>
               <td className="border px-2 py-1">{sale.total.toFixed(2)}</td>
             </tr>
           ))}
-          {state.recentSales.length === 0 && (
+          {data.length === 0 && (
             <tr>
               <td className="border px-2 py-1 text-center" colSpan={3}>
-                No sales yet.
+                No sales found.
               </td>
             </tr>
           )}

--- a/next_frontend_web/src/services/sales.ts
+++ b/next_frontend_web/src/services/sales.ts
@@ -1,5 +1,16 @@
-import api from './apiClient';
+import api, { accessToken } from './apiClient';
 import { Sale } from '../types';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+
+const buildQuery = (filters: Record<string, any>) => {
+  const params = new URLSearchParams();
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value) params.append(key, String(value));
+  });
+  const query = params.toString();
+  return query ? `?${query}` : '';
+};
 
 export const getSales = () => api.get<Sale[]>('/api/v1/sales');
 export const createSale = (payload: Partial<Sale>) => api.post<Sale>('/api/v1/sales', payload);
@@ -17,3 +28,19 @@ export const applyPromotion = (id: string, code: string) =>
 
 export const applyLoyaltyPoints = (id: string, points: number) =>
   api.post<Sale>(`/api/v1/sales/${id}/loyalty`, { points });
+
+export const getSalesHistory = (filters: Record<string, any> = {}) =>
+  api.get<Sale[]>(`/api/v1/sales/history${buildQuery(filters)}`);
+
+export const exportSalesHistory = async (
+  filters: Record<string, any> = {}
+) => {
+  const res = await fetch(
+    `${API_BASE_URL}/api/v1/sales/history/export${buildQuery(filters)}`,
+    {
+      headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
+    }
+  );
+  if (!res.ok) throw new Error('Failed to export sales history');
+  return res.blob();
+};


### PR DESCRIPTION
## Summary
- add sales history service with filter and export helpers
- add filter controls and export button to sales history page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af4828757c832cb749ceb977d83a81