### PR TITLE
feat: add invoice and quotations management

### DIFF
--- a/next_frontend_web/src/components/ERP/Sales/QuotesView.tsx
+++ b/next_frontend_web/src/components/ERP/Sales/QuotesView.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from 'react';
+import {
+  getQuotes,
+  createQuote,
+  updateQuote,
+  deleteQuote,
+} from '../../../services/sales';
+import { Quote } from '../../../types';
+
+const QuotesView: React.FC = () => {
+  const [quotes, setQuotes] = useState<Quote[]>([]);
+  const [form, setForm] = useState<Partial<Quote>>({
+    quoteNumber: '',
+    total: 0,
+  });
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const load = async () => {
+    try {
+      const data = await getQuotes();
+      setQuotes(data);
+    } catch {
+      setQuotes([]);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (editingId) {
+      await updateQuote(editingId, form);
+    } else {
+      await createQuote(form);
+    }
+    setForm({ quoteNumber: '', total: 0 });
+    setEditingId(null);
+    load();
+  };
+
+  const startEdit = (quote: Quote) => {
+    setForm({ quoteNumber: quote.quoteNumber, total: quote.total });
+    setEditingId(quote._id);
+  };
+
+  const handleDelete = async (id: string) => {
+    await deleteQuote(id);
+    load();
+  };
+
+    const printQuote = (_quote: Quote) => window.print();
+  const shareQuote = (quote: Quote) => {
+    const msg = `Quote ${quote.quoteNumber} Total: ${quote.total.toFixed(2)}`;
+    window.open(`mailto:?subject=Quote&body=${encodeURIComponent(msg)}`);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-semibold">Quotes</h2>
+      <form onSubmit={handleSubmit} className="space-x-2">
+        <input
+          placeholder="Quote Number"
+          value={form.quoteNumber || ''}
+          onChange={e => setForm({ ...form, quoteNumber: e.target.value })}
+          className="border px-2 py-1"
+        />
+        <input
+          type="number"
+          placeholder="Total"
+          value={form.total ?? ''}
+          onChange={e => setForm({ ...form, total: Number(e.target.value) })}
+          className="border px-2 py-1"
+        />
+        <button
+          type="submit"
+          className="px-3 py-1 bg-blue-500 text-white rounded"
+        >
+          {editingId ? 'Update' : 'Create'}
+        </button>
+      </form>
+      <table className="w-full border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="p-2 border">Quote #</th>
+            <th className="p-2 border">Total</th>
+            <th className="p-2 border">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {quotes.map(q => (
+            <tr key={q._id} className="border-t">
+              <td className="p-2 border">{q.quoteNumber}</td>
+              <td className="p-2 border">{q.total}</td>
+              <td className="p-2 border space-x-2">
+                <button
+                  onClick={() => startEdit(q)}
+                  className="px-2 py-1 bg-yellow-500 text-white rounded"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={() => handleDelete(q._id)}
+                  className="px-2 py-1 bg-red-500 text-white rounded"
+                >
+                  Delete
+                </button>
+                <button
+                  onClick={() => printQuote(q)}
+                  className="px-2 py-1 bg-gray-200 rounded"
+                >
+                  Print
+                </button>
+                <button
+                  onClick={() => shareQuote(q)}
+                  className="px-2 py-1 bg-green-500 text-white rounded"
+                >
+                  Share
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default QuotesView;
+

--- a/next_frontend_web/src/components/Layout/Sidebar.tsx
+++ b/next_frontend_web/src/components/Layout/Sidebar.tsx
@@ -70,6 +70,7 @@ const Sidebar: React.FC = () => {
       subItems: [
         { label: 'POS', view: 'sales', icon: ShoppingCart },
         { label: 'Invoice', view: 'sales-invoice', icon: FileText },
+        { label: 'Quotes', view: 'sales-quotes', icon: FileText },
         { label: 'Returns', view: 'sales-returns', icon: Undo2 },
         { label: 'Sale History', view: 'sales-history', icon: History },
       ],
@@ -160,6 +161,7 @@ const Sidebar: React.FC = () => {
     dashboard: '/dashboard',
     sales: '/sales',
     'sales-invoice': '/sales/invoice',
+    'sales-quotes': '/sales/quotes',
     'sales-returns': '/sales/returns',
     'sales-history': '/sales/history',
     'purchase-entry': '/purchases/grn',

--- a/next_frontend_web/src/pages/sales/quotes.tsx
+++ b/next_frontend_web/src/pages/sales/quotes.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { useAuth } from '../../context/AuthContext';
+import MainLayout from '../../components/Layout/MainLayout';
+import QuotesView from '../../components/ERP/Sales/QuotesView';
+import { ROLES } from '../../types';
+
+const QuotesPage: React.FC = () => {
+  const { state, hasRole } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!state.isInitialized) return;
+    if (!state.isAuthenticated) {
+      router.replace('/login');
+    }
+  }, [state.isInitialized, state.isAuthenticated, router]);
+
+  if (!state.isInitialized || !state.isAuthenticated) return null;
+  if (!hasRole([ROLES.SUPER_ADMIN, ROLES.ADMIN, ROLES.MANAGER, ROLES.SALES]))
+    return <div>Access denied</div>;
+
+  return (
+    <MainLayout>
+      <QuotesView />
+    </MainLayout>
+  );
+};
+
+export default QuotesPage;
+

--- a/next_frontend_web/src/services/sales.ts
+++ b/next_frontend_web/src/services/sales.ts
@@ -1,5 +1,5 @@
 import api, { accessToken } from './apiClient';
-import { Sale } from '../types';
+import { Sale, Quote } from '../types';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
 
@@ -28,6 +28,24 @@ export const applyPromotion = (id: string, code: string) =>
 
 export const applyLoyaltyPoints = (id: string, points: number) =>
   api.post<Sale>(`/api/v1/sales/${id}/loyalty`, { points });
+
+// Invoice CRUD
+export const getInvoice = (id: string) => api.get<Sale>(`/api/v1/sales/${id}`);
+export const updateInvoice = (id: string, payload: Partial<Sale>) =>
+  api.put<Sale>(`/api/v1/sales/${id}`, payload);
+export const deleteInvoice = (id: string) =>
+  api.delete<void>(`/api/v1/sales/${id}`);
+
+// Quote CRUD
+export const getQuotes = () => api.get<Quote[]>('/api/v1/sales/quotes');
+export const getQuote = (id: string) =>
+  api.get<Quote>(`/api/v1/sales/quotes/${id}`);
+export const createQuote = (payload: Partial<Quote>) =>
+  api.post<Quote>('/api/v1/sales/quotes', payload);
+export const updateQuote = (id: string, payload: Partial<Quote>) =>
+  api.put<Quote>(`/api/v1/sales/quotes/${id}`, payload);
+export const deleteQuote = (id: string) =>
+  api.delete<void>(`/api/v1/sales/quotes/${id}`);
 
 export const getSalesHistory = (filters: Record<string, any> = {}) =>
   api.get<Sale[]>(`/api/v1/sales/history${buildQuery(filters)}`);

--- a/next_frontend_web/src/types/index.ts
+++ b/next_frontend_web/src/types/index.ts
@@ -224,6 +224,29 @@ export interface Sale extends AuditFields {
   date: string;
 }
 
+export interface Quote extends AuditFields {
+  _id: string;
+  quoteNumber: string;
+  customerId?: string;
+  items: Array<{
+    productId: string;
+    productName: string;
+    quantity: number;
+    unitPrice: number;
+    totalPrice: number;
+    discount?: number;
+  }>;
+  subtotal: number;
+  discount: number;
+  tax: number;
+  total: number;
+  status?: 'draft' | 'sent' | 'accepted';
+  companyId: string;
+  locationId: string;
+  userId: string;
+  date: string;
+}
+
 export interface Supplier extends AuditFields {
   _id: string;
   name: string;
@@ -267,6 +290,7 @@ export type SidebarView =
   | 'dashboard'
   | 'sales'
   | 'sales-invoice'
+  | 'sales-quotes'
   | 'sales-returns'
   | 'sales-history'
   | 'purchase-entry'


### PR DESCRIPTION
## Summary
- add invoice and quote CRUD APIs to sales service
- fetch invoices from backend in invoice view
- create quotation management pages with create/update/delete/print/share and sidebar link

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af491914d4832cb46e7203b6694906