### PR TITLE
fix: use sale object in sale return lookup

### DIFF
--- a/next_frontend_web/src/components/ERP/Sales/SaleReturn.tsx
+++ b/next_frontend_web/src/components/ERP/Sales/SaleReturn.tsx
@@ -19,10 +19,10 @@ const SaleReturn: React.FC = () => {
   const lookupSale = async () => {
     if (!invoice) return;
     try {
-      const { data } = await returns.searchSale(invoice);
-      setSale(data);
+      const sale = await returns.searchSale(invoice);
+      setSale(sale);
       setItems(
-        data.items.map(i => ({
+        sale.items.map(i => ({
           productId: i.productId,
           productName: i.productName,
           quantity: i.quantity,


### PR DESCRIPTION
## Summary
- fix SaleReturn lookup to use sale object directly from returns.searchSale

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af4b680190832c937de17b71b3987f