### PR TITLE
refactor: remove redundant type re-exports

### DIFF
--- a/next_frontend_web/src/types/index.ts
+++ b/next_frontend_web/src/types/index.ts
@@ -592,9 +592,6 @@ export type {
   Customer as CustomerType,
   Sale as SaleType,
   Supplier as SupplierType,
-  Brand,
-  Unit,
-  DeviceSession,
   AuthAction,
   AppAction,
 };


### PR DESCRIPTION
## Summary
- remove Brand, Unit and DeviceSession from types re-export block
- ensure Unit and DeviceSession are exported only at declaration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af4c5ffb98832cb2a390f9d93c8df1